### PR TITLE
Fix generation for strings with repeating or reordered arguments 

### DIFF
--- a/Sources/StringExtractor/ExtractionError.swift
+++ b/Sources/StringExtractor/ExtractionError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ExtractionError: LocalizedError {
+public enum ExtractionError: Error {
     public struct Context {
         /// The key of the localization being parsed
         public let key: String
@@ -10,4 +10,13 @@ public enum ExtractionError: LocalizedError {
     }
 
     case localizationCorrupt(Context)
+}
+
+extension ExtractionError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .localizationCorrupt(let context):
+            "String ‘\(context.key)‘ was corrupt: \(context.debugDescription)"
+        }
+    }
 }

--- a/Sources/StringExtractor/Resource+Extract.swift
+++ b/Sources/StringExtractor/Resource+Extract.swift
@@ -1,0 +1,51 @@
+import StringResource
+
+extension Resource {
+    static func extract(
+        from segments: [StringParser.ParsedSegment],
+        labels: [Int: String] = [:]
+    ) throws -> (arguments: [Argument], defaultValue: [StringSegment]) {
+        var defaultValue: [StringSegment] = [], arguments: [Int: Argument] = [:]
+        var nextUnspecifiedPosition = 1
+
+        // Convert the parsed string into a default value and extract the arguments
+        for segment in segments {
+            switch segment {
+            case .string(let contents):
+                defaultValue.append(.string(contents))
+            case .placeholder(let placeholder, let specifiedPosition):
+                // Figure out the position of the argument for this placeholder
+                let position: Int
+                if let specifiedPosition {
+                    position = specifiedPosition
+                } else {
+                    position = nextUnspecifiedPosition
+                    nextUnspecifiedPosition += 1
+                }
+
+                // Create the argument for this placeholder
+                let name = "arg\(position)"
+                let argument = Argument(
+                    label: labels[position],
+                    name: name,
+                    type: placeholder.type
+                )
+
+                // If the same argument is represented by many placeholders,
+                // ensure that they use the same type
+                if let existing = arguments[position], existing.type != argument.type {
+                    // TODO: Raise error.
+                    assertionFailure("Repeated argument has mismatching placeholder types")
+                }
+
+                defaultValue.append(.interpolation(name))
+                arguments[position] = argument
+            }
+        }
+
+        // TODO: Raise error for missing arguments
+
+        return (arguments.sorted(by: { $0.key < $1.key }).map(\.value), defaultValue)
+    }
+}
+

--- a/Sources/StringExtractor/Resource+StringUnit.swift
+++ b/Sources/StringExtractor/Resource+StringUnit.swift
@@ -53,7 +53,7 @@ extension Resource {
         let labels = Dictionary(uniqueKeysWithValues: labelSequence ?? [])
 
         // Convert the parsed arguments and labels into the correct data
-        return try extract(from: segments, labels: labels)
+        return try extract(from: segments, labels: labels, key: key)
     }
 
     private static func preferredStringUnit(

--- a/Sources/StringExtractor/Resource+StringUnit.swift
+++ b/Sources/StringExtractor/Resource+StringUnit.swift
@@ -46,37 +46,14 @@ extension Resource {
         // Parse the raw segments
         let segments = StringParser.parse(stringUnit.value, expandingSubstitutions: substitutions ?? [:])
 
-        // Populate the default values using the raw parser result
-        var arguments: [Argument] = []
-        var defaultValue: [StringSegment] = []
-
         // Calculate labels from substitutions
         let labelSequence = localization.substitutions?.map {
             ($0.value.argNum, SwiftIdentifier.variableIdentifier(for: $0.key))
-        } ?? []
-        let labels = Dictionary(uniqueKeysWithValues: labelSequence)
-
-        // Convert the parsed string into a default value and extract the arguments
-        for segment in segments {
-            let argNum = arguments.count + 1
-            let argName = "arg\(argNum)"
-
-            switch segment {
-            case .string(let contents):
-                defaultValue.append(.string(contents))
-            case .placeholder(let placeholder):
-                defaultValue.append(.interpolation(argName))
-                arguments.append(
-                    Argument(
-                        label: labels[argNum],
-                        name: argName,
-                        type: placeholder.type
-                    )
-                )
-            }
         }
+        let labels = Dictionary(uniqueKeysWithValues: labelSequence ?? [])
 
-        return (arguments, defaultValue)
+        // Convert the parsed arguments and labels into the correct data
+        return try extract(from: segments, labels: labels)
     }
 
     private static func preferredStringUnit(

--- a/Sources/StringExtractor/StringExtractor+StringCatalog.swift
+++ b/Sources/StringExtractor/StringExtractor+StringCatalog.swift
@@ -1,0 +1,33 @@
+import StringCatalog
+import StringResource
+
+extension StringExtractor {
+    public static func extractResources(
+        from catalog: StringCatalog
+    ) throws -> Result {
+        try collect { resources, issues in
+            for (key, value) in catalog.strings {
+                // Retrieve the source localization for the given key. If it's missing, we skip it
+                guard let localization = value.localizations?[catalog.sourceLanguage] else {
+                    issues.append(ExtractionIssue(key: key, reason: .missingSourceLocalization(catalog.sourceLanguage)))
+                    continue
+                }
+
+                // Only process manual strings
+                guard value.extractionState == .manual else {
+                    issues.append(ExtractionIssue(key: key, reason: .wrongExtractionState(value.extractionState)))
+                    continue
+                }
+
+                // Attempt to process the resource from the catalog data
+                resources.append(
+                    try Resource(
+                        key: key,
+                        comment: value.comment,
+                        sourceLocalization: localization
+                    )
+                )
+            }
+        }
+    }
+}

--- a/Sources/StringExtractor/StringExtractor+Util.swift
+++ b/Sources/StringExtractor/StringExtractor+Util.swift
@@ -1,0 +1,14 @@
+import Foundation
+import StringResource
+
+extension StringExtractor {
+    static func collect(
+        collector: (inout [Resource], inout [ExtractionIssue]) throws -> Void
+    ) rethrows -> Result {
+        var resources: [Resource] = [], issues: [ExtractionIssue] = []
+        
+        try collector(&resources, &issues)
+        
+        return (resources: resources.sorted(), issues: issues)
+    }
+}

--- a/Sources/StringExtractor/StringExtractor.swift
+++ b/Sources/StringExtractor/StringExtractor.swift
@@ -1,40 +1,5 @@
-import StringCatalog
 import StringResource
 
 public struct StringExtractor {
     public typealias Result = (resources: [Resource], issues: [ExtractionIssue])
-
-    public static func extractResources(
-        from catalog: StringCatalog
-    ) throws -> Result {
-        var resources: [Resource] = [], issues: [ExtractionIssue] = []
-
-        for (key, value) in catalog.strings {
-            // Retrieve the source localization for the given key. If it's missing, we skip it
-            guard let localization = value.localizations?[catalog.sourceLanguage] else {
-                issues.append(ExtractionIssue(key: key, reason: .missingSourceLocalization(catalog.sourceLanguage)))
-                continue
-            }
-
-            // Only process manual strings
-            guard value.extractionState == .manual else {
-                issues.append(ExtractionIssue(key: key, reason: .wrongExtractionState(value.extractionState)))
-                continue
-            }
-
-            // Attempt to process the resource from the catalog data
-            resources.append(
-                try Resource(
-                    key: key,
-                    comment: value.comment,
-                    sourceLocalization: localization
-                )
-            )
-        }
-
-        return (
-            resources: resources.sorted { $0.identifier.localizedStandardCompare($1.identifier) == .orderedAscending },
-            issues: issues
-        )
-    }
 }

--- a/Sources/StringExtractor/StringParser.swift
+++ b/Sources/StringExtractor/StringParser.swift
@@ -5,7 +5,7 @@ import RegexBuilder
 struct StringParser {
     enum ParsedSegment: Equatable {
         case string(contents: String)
-        case placeholder(PlaceholderType)
+        case placeholder(PlaceholderType, position: Int?)
     }
 
     /// Parse the given input string including the expansion of the given substitutions
@@ -31,8 +31,8 @@ struct StringParser {
             }
 
             // Now create a segment for the match itself
-            let output: (_, placeholder: PlaceholderType) = match.output
-            segments.append(.placeholder(output.placeholder))
+            let output: (_, position: Int?, placeholder: PlaceholderType) = match.output
+            segments.append(.placeholder(output.placeholder, position: output.position))
 
             // Update the last index for the next iteration
             lastIndex = match.range.upperBound
@@ -55,7 +55,11 @@ extension StringParser {
 
         // Optional, positional information
         Optionally {
-            OneOrMore(.digit)
+            TryCapture {
+                OneOrMore(.digit)
+            } transform: { rawValue in
+                Int(rawValue)
+            }
             "$"
         }
 

--- a/Sources/StringResource/Resource.swift
+++ b/Sources/StringResource/Resource.swift
@@ -30,3 +30,9 @@ public struct Resource: Equatable {
         self.defaultValue = defaultValue
     }
 }
+
+extension Resource: Comparable {
+    public static func < (lhs: Resource, rhs: Resource) -> Bool {
+        lhs.identifier.localizedStandardCompare(rhs.identifier) == .orderedAscending
+    }
+}

--- a/Tests/XCStringsToolTests/__Fixtures__/!MismatchingArgumentType.xcstrings
+++ b/Tests/XCStringsToolTests/__Fixtures__/!MismatchingArgumentType.xcstrings
@@ -1,0 +1,18 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Key" : {
+      "comment" : "Referencing the same argument but with two different format specifiers ",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld or %1$@"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Tests/XCStringsToolTests/__Fixtures__/!MissingArgument.xcstrings
+++ b/Tests/XCStringsToolTests/__Fixtures__/!MissingArgument.xcstrings
@@ -1,0 +1,18 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Key" : {
+      "comment" : "A string that contains positional specifiers that results in the first argument to be missing",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$@, %3$@"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Tests/XCStringsToolTests/__Fixtures__/Localizable.xcstrings
+++ b/Tests/XCStringsToolTests/__Fixtures__/Localizable.xcstrings
@@ -78,7 +78,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld: People liked %#@count@ posts"
+            "value" : "%lld: People liked %#@count@ posts"
           },
           "substitutions" : {
             "count" : {
@@ -88,7 +88,7 @@
                 "plural" : {
                   "one" : {
                     "stringUnit" : {
-                      "state" : "needs_review",
+                      "state" : "translated",
                       "value" : "%arg"
                     }
                   },

--- a/Tests/XCStringsToolTests/__Fixtures__/Positional.xcstrings
+++ b/Tests/XCStringsToolTests/__Fixtures__/Positional.xcstrings
@@ -1,0 +1,42 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "reorder" : {
+      "comment" : "A string where the second argument is at the front of the string and the first argument is at the end",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Second: %2$@ - First: %1$lld"
+          }
+        }
+      }
+    },
+    "repeatExplicit" : {
+      "comment" : "A string that uses the same argument twice",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld, I repeat: %1$lld"
+          }
+        }
+      }
+    },
+    "repeatImplicit" : {
+      "comment" : "A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, are you there? %1$@?"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Tests/XCStringsToolTests/__Fixtures__/Substitution.xcstrings
+++ b/Tests/XCStringsToolTests/__Fixtures__/Substitution.xcstrings
@@ -8,7 +8,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@! There %#@total.strings@ and you have %#@remaining.strings@ remaining"
+            "value" : "%@! There %#@total.strings@ and you have %#@remaining.strings@ remaining"
           },
           "substitutions" : {
             "remaining.strings" : {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    /// Constant values for the Positional Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .positional.foo)
+    /// value // "bar"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.positional.foo)
+    /// ```
+    internal struct Positional {
+
+        /// A string where the second argument is at the front of the string and the first argument is at the end
+        internal func reorder(_ arg1: Int, _ arg2: String) -> LocalizedStringResource {
+            LocalizedStringResource(
+                "reorder",
+                defaultValue: ###"Second: \###(arg2) - First: \###(arg1)"###,
+                table: "Positional",
+                bundle: .current
+            )
+        }
+
+        /// A string that uses the same argument twice
+        internal func repeatExplicit(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(
+                "repeatExplicit",
+                defaultValue: ###"\###(arg1), I repeat: \###(arg1)"###,
+                table: "Positional",
+                bundle: .current
+            )
+        }
+
+        /// A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance
+        internal func repeatImplicit(_ arg1: String) -> LocalizedStringResource {
+            LocalizedStringResource(
+                "repeatImplicit",
+                defaultValue: ###"\###(arg1), are you there? \###(arg1)?"###,
+                table: "Positional",
+                bundle: .current
+            )
+        }
+    }
+
+    /// Constant values for the Positional Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .positional.foo)
+    /// value // "bar"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.positional.foo)
+    /// ```
+    internal static let positional = Positional()
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    #if !SWIFT_PACKAGE
+    private class BundleLocator {
+    }
+    #endif
+
+    static var current: Self {
+        #if SWIFT_PACKAGE
+        .atURL(Bundle.module.bundleURL)
+        #else
+        .forClass(BundleLocator.self)
+        #endif
+    }
+}


### PR DESCRIPTION
When using positional specifiers (i.e `%1$@`) to explicitly reposition values or to repeat them, XCStrings Tool would fail to correctly handle this and result in either generating code that required two arguments, or placing the arguments in the wrong positon.

This Pull Request fixes that, and adds some validation that raises issues early on if you have gotten your strings into an invalid state:

1. `"%1$lld or %1$@"`
    - A scenario where `arg1` is defined as both `Int` and `String`
3. `"%2$@, %3$@"`
    - A scenario where an argument (`arg1`) is omitted from the string