### PR TITLE
Add cases for `%u`, `%x` and `%o` to produce `UInt` arguments

### DIFF
--- a/Sources/StringExtractor/PlaceholderType.swift
+++ b/Sources/StringExtractor/PlaceholderType.swift
@@ -1,6 +1,6 @@
 // https://github.com/SwiftGen/SwiftGen/blob/stable/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
 enum PlaceholderType {
-    case object, float, int, char, cString, pointer
+    case object, float, int, uint, char, cString, pointer
 
     /// Create an instance using a formatSpecifier 
     init?(formatSpecifier: some StringProtocol) {
@@ -10,8 +10,10 @@ enum PlaceholderType {
             self = .object
         case "a", "e", "f", "g":
             self = .float
-        case "d", "i", "o", "u", "x":
+        case "d", "i":
             self = .int
+        case "u", "x", "X", "o":
+            self = .uint
         case "c":
             self = .char
         case "s":
@@ -28,6 +30,7 @@ enum PlaceholderType {
         case .object: "String"
         case .float: "Double"
         case .int: "Int"
+        case .uint: "UInt"
         case .char: "CChar"
         case .cString: "UnsafePointer<CChar>"
         case .pointer: "UnsafeRawPointer"

--- a/Tests/XCStringsToolTests/__Fixtures__/FormatSpecifiers.xcstrings
+++ b/Tests/XCStringsToolTests/__Fixtures__/FormatSpecifiers.xcstrings
@@ -85,6 +85,18 @@
         }
       }
     },
+    "o" : {
+      "comment" : "%o should convert to a UInt argument",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test %o"
+          }
+        }
+      }
+    },
     "p" : {
       "comment" : "%p should convert to an UnsafeRawPointer argument",
       "extractionState" : "manual",
@@ -105,6 +117,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Test %s"
+          }
+        }
+      }
+    },
+    "u" : {
+      "comment" : "%u should convert to a UInt argument",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test %u"
+          }
+        }
+      }
+    },
+    "x" : {
+      "comment" : "%x should convert to a UInt argument",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test %x"
           }
         }
       }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -84,6 +84,16 @@ extension LocalizedStringResource {
             )
         }
 
+        /// %o should convert to a UInt argument
+        internal func o(_ arg1: UInt) -> LocalizedStringResource {
+            LocalizedStringResource(
+                "o",
+                defaultValue: ###"Test \###(arg1)"###,
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
         /// %p should convert to an UnsafeRawPointer argument
         internal func p(_ arg1: UnsafeRawPointer) -> LocalizedStringResource {
             LocalizedStringResource(
@@ -98,6 +108,26 @@ extension LocalizedStringResource {
         internal func s(_ arg1: UnsafePointer<CChar>) -> LocalizedStringResource {
             LocalizedStringResource(
                 "s",
+                defaultValue: ###"Test \###(arg1)"###,
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %u should convert to a UInt argument
+        internal func u(_ arg1: UInt) -> LocalizedStringResource {
+            LocalizedStringResource(
+                "u",
+                defaultValue: ###"Test \###(arg1)"###,
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %x should convert to a UInt argument
+        internal func x(_ arg1: UInt) -> LocalizedStringResource {
+            LocalizedStringResource(
+                "x",
                 defaultValue: ###"Test \###(arg1)"###,
                 table: "FormatSpecifiers",
                 bundle: .current


### PR DESCRIPTION
Fixes #22 