### PR TITLE
Disable use of auxiliary file to prevent permission error on XcodeCloud

### DIFF
--- a/Sources/xcstrings-tool/Generate.swift
+++ b/Sources/xcstrings-tool/Generate.swift
@@ -56,7 +56,7 @@ struct Generate: ParsableCommand {
             try createDirectoryIfNeeded(for: output)
 
             // Write the source to disk
-            try source.write(to: output, atomically: true, encoding: .utf8)
+            try source.write(to: output, atomically: false, encoding: .utf8)
             note("Output written to ‘\(output.path(percentEncoded: false))‘")
         }
     }


### PR DESCRIPTION
fixes #35 

In XcodeCloud environment, file system seems more strict than local machine.

`xcstrings-tool` implementation uses `try someString.write(to: outputURL, atomically: true, encoding: .utf8)` to write generated contents to file. 
When `atomically` is `true` , contents will be written to intermediate file and then file will be moved to `outputURL` . But XcodeCloud seems to deny file writes outside of `pluginWorkDirectory` even if it is temporary file made by Foundation framework.

The easiest way to prevent this error is making `atomically` to be `false` if atomicity is not very important.

What do you think of it?