### PR TITLE
Fix compatibility with swift-argument-parser 1.3.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
+        "revision" : "46989693916f56d1186bd59ac15124caef896560",
+        "version" : "1.3.1"
       }
     },
     {

--- a/Sources/xcstrings-tool/Generate.swift
+++ b/Sources/xcstrings-tool/Generate.swift
@@ -12,14 +12,14 @@ struct Generate: ParsableCommand {
         completion: .file(extensions: ["xcstrings"]),
         transform: { URL(filePath: $0, directoryHint: .notDirectory) }
     )
-    var input
+    var input: URL
 
     @Argument(
         help: "Path to write generated Swift output",
         completion: .file(extensions: ["swift"]),
         transform: { URL(filePath: $0, directoryHint: .notDirectory) }
     )
-    var output
+    var output: URL
 
     @Option(
         name: .shortAndLong,


### PR DESCRIPTION
The latest version of swift-argument-parser has a _fix_ that causes an incompatibility with the current `Generate` command definition:

> - `@Option`- and `@Argument`-annotated optional properties that use a transform closure for parsing can now be declared without ambiguity. (https://github.com/apple/swift-argument-parser/pull/619)

https://github.com/apple/swift-argument-parser/releases/tag/1.3.1

This causes the issue observed in #44.

The fix however is simple, we just need to explicitly annotate `input` and `output` as `URL` so that they are not interpreted as optional types when using 1.3.1.