### PR TITLE
Support iOS 15/macOS 12

### DIFF
--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -70,7 +70,7 @@ public struct StringGenerator {
                 // BundleDescription
                 EnumDeclSyntax(
                     modifiers: [
-                        DeclModifierSyntax(name: accessLevel.token)
+                        DeclModifierSyntax(name: .keyword(.fileprivate))
                     ],
                     name: .type(.BundleDescription),
                     memberBlockBuilder: {

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -120,7 +120,7 @@ public struct StringGenerator {
                         // Properties
                         VariableDeclSyntax(
                             modifiers: [
-                                DeclModifierSyntax(name: accessLevel.token),
+                                DeclModifierSyntax(name: .keyword(.fileprivate)),
                             ],
                             .let,
                             name: PatternSyntax(IdentifierPatternSyntax(identifier: "key")),
@@ -130,7 +130,7 @@ public struct StringGenerator {
                         )
                         VariableDeclSyntax(
                             modifiers: [
-                                DeclModifierSyntax(name: accessLevel.token),
+                                DeclModifierSyntax(name: .keyword(.fileprivate)),
                             ],
                             .let,
                             name: PatternSyntax(IdentifierPatternSyntax(identifier: "defaultValue")),
@@ -140,7 +140,7 @@ public struct StringGenerator {
                         )
                         VariableDeclSyntax(
                             modifiers: [
-                                DeclModifierSyntax(name: accessLevel.token),
+                                DeclModifierSyntax(name: .keyword(.fileprivate)),
                             ],
                             .let,
                             name: PatternSyntax(IdentifierPatternSyntax(identifier: "table")),
@@ -152,9 +152,9 @@ public struct StringGenerator {
                         )
                         VariableDeclSyntax(
                             modifiers: [
-                                DeclModifierSyntax(name: accessLevel.token),
+                                DeclModifierSyntax(name: .keyword(.fileprivate)),
                             ],
-                            .var,
+                            .let,
                             name: PatternSyntax(IdentifierPatternSyntax(identifier: "locale")),
                             type: TypeAnnotationSyntax(
                                 type: IdentifierTypeSyntax(name: "Locale")
@@ -162,7 +162,7 @@ public struct StringGenerator {
                         )
                         VariableDeclSyntax(
                             modifiers: [
-                                DeclModifierSyntax(name: accessLevel.token),
+                                DeclModifierSyntax(name: .keyword(.fileprivate)),
                             ],
                             .let,
                             name: PatternSyntax(IdentifierPatternSyntax(identifier: "bundle")),

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -36,10 +36,24 @@ public struct StringGenerator {
             generateImports()
                 .with(\.trailingTrivia, .newlines(2))
 
-            generateLocalizedStringResourceExtension()
+            generateStringExtension()
+                .with(\.trailingTrivia, .newlines(2))
+
+            generateStringsTableExtension()
                 .with(\.trailingTrivia, .newlines(2))
 
             generateBundleDescriptionExtension()
+                .with(\.trailingTrivia, .newlines(2))
+
+            generateBundleExtension()
+                .with(\.trailingTrivia, .newlines(2))
+
+            // iOS 16+ LocalisedStringResource
+
+            generateFoundationBundleDescriptionExtension()
+                .with(\.trailingTrivia, .newlines(2))
+
+            generateLocalizedStringResourceExtension()
         }
     }
 
@@ -53,61 +67,303 @@ public struct StringGenerator {
         )
     }
 
-    func generateLocalizedStringResourceExtension() -> ExtensionDeclSyntax {
+    func generateStringExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
             attributes: [
-                .attribute(.init(availability: .wwdc2022))
+                .attribute(.init(availability: .wwdc2021))
                     .with(\.trailingTrivia, .newline)
             ],
-            extendedType: IdentifierTypeSyntax(name: "LocalizedStringResource"),
+            extendedType: IdentifierTypeSyntax(name: "String"),
             memberBlock: MemberBlockSyntax {
                 // Table struct
                 StructDeclSyntax(
-                    leadingTrivia: typeDocumentation,
+//                    leadingTrivia: typeDocumentation,
                     modifiers: [
                         DeclModifierSyntax(name: accessLevel.token)
                     ],
                     name: structToken,
                     memberBlockBuilder: {
-                        for resource in resources {
-                            resource.declaration(tableName: tableName, accessLevel: accessLevel.token)
+                        // BundleDescription
+                        EnumDeclSyntax(
+                            modifiers: [
+                                DeclModifierSyntax(name: accessLevel.token)
+                            ],
+                            name: bundleDescriptionNameToken,
+                            memberBlockBuilder: {
+                                EnumCaseDeclSyntax {
+                                    EnumCaseElementSyntax(name: .identifier("main"))
+                                }
+                                EnumCaseDeclSyntax {
+                                    EnumCaseElementSyntax(
+                                        name: .identifier("atURL"),
+                                        parameterClause: EnumCaseParameterClauseSyntax(
+                                            parameters: [
+                                                "URL"
+                                            ]
+                                        )
+                                    )
+                                }
+                                EnumCaseDeclSyntax {
+                                    EnumCaseElementSyntax(
+                                        name: .identifier("forClass"),
+                                        parameterClause: EnumCaseParameterClauseSyntax(
+                                            parameters: [
+                                                "AnyClass"
+                                            ]
+                                        )
+                                    )
+                                }
+                            },
+                            trailingTrivia: .newlines(2)
+                        )
+
+                        // Properties
+                        VariableDeclSyntax(
+                            modifiers: [
+                                DeclModifierSyntax(name: accessLevel.token),
+                            ],
+                            .let,
+                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "key")),
+                            type: TypeAnnotationSyntax(
+                                type: IdentifierTypeSyntax(name: "StaticString")
+                            )
+                        )
+                        VariableDeclSyntax(
+                            modifiers: [
+                                DeclModifierSyntax(name: accessLevel.token),
+                            ],
+                            .let,
+                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "defaultValue")),
+                            type: TypeAnnotationSyntax(
+                                type: IdentifierTypeSyntax(name: "LocalizationValue")
+                            )
+                        )
+                        VariableDeclSyntax(
+                            modifiers: [
+                                DeclModifierSyntax(name: accessLevel.token),
+                            ],
+                            .let,
+                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "table")),
+                            type: TypeAnnotationSyntax(
+                                type: OptionalTypeSyntax(
+                                    wrappedType: IdentifierTypeSyntax(name: "String")
+                                )
+                            )
+                        )
+                        VariableDeclSyntax(
+                            modifiers: [
+                                DeclModifierSyntax(name: accessLevel.token),
+                            ],
+                            .var,
+                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "locale")),
+                            type: TypeAnnotationSyntax(
+                                type: IdentifierTypeSyntax(name: "Locale")
+                            )
+                        )
+                        VariableDeclSyntax(
+                            modifiers: [
+                                DeclModifierSyntax(name: accessLevel.token),
+                            ],
+                            .let,
+                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "bundle")),
+                            type: TypeAnnotationSyntax(
+                                type: IdentifierTypeSyntax(name: "BundleDescription")
+                            )
+                        ).with(\.trailingTrivia, .newlines(2))
+
+                        // Init
+                        InitializerDeclSyntax(
+                            modifiers: [
+                                DeclModifierSyntax(name: .keyword(.fileprivate)),
+                            ],
+                            signature: FunctionSignatureSyntax(
+                                parameterClause: FunctionParameterClauseSyntax {
+                                    FunctionParameterSyntax(
+                                        firstName: "key",
+                                        type: IdentifierTypeSyntax(name: "StaticString")
+                                    )
+                                    .with(\.trailingComma, .commaToken())
+                                    .with(\.leadingTrivia, .newline)
+
+                                    FunctionParameterSyntax(
+                                        firstName: "defaultValue",
+                                        type: IdentifierTypeSyntax(name: "LocalizationValue")
+                                    )
+                                    .with(\.trailingComma, .commaToken())
+                                    .with(\.leadingTrivia, .newline)
+
+                                    FunctionParameterSyntax(
+                                        firstName: "table",
+                                        type: OptionalTypeSyntax(
+                                            wrappedType: IdentifierTypeSyntax(name: "String")
+                                        )
+                                    )
+                                    .with(\.trailingComma, .commaToken())
+                                    .with(\.leadingTrivia, .newline)
+
+                                    FunctionParameterSyntax(
+                                        firstName: "locale",
+                                        type: IdentifierTypeSyntax(name: "Locale")
+                                    )
+                                    .with(\.trailingComma, .commaToken())
+                                    .with(\.leadingTrivia, .newline)
+
+                                    FunctionParameterSyntax(
+                                        firstName: "bundle",
+                                        type: IdentifierTypeSyntax(name: "BundleDescription")
+                                    )
+                                    .with(\.leadingTrivia, .newline)
+                                }
+                            )
+                        ) {
+                            InfixOperatorExprSyntax(
+                                leftOperand: MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                                    name: "key"
+                                ),
+                                operator: AssignmentExprSyntax(),
+                                rightOperand: DeclReferenceExprSyntax(baseName: "key")
+                            )
+                            InfixOperatorExprSyntax(
+                                leftOperand: MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                                    name: "defaultValue"
+                                ),
+                                operator: AssignmentExprSyntax(),
+                                rightOperand: DeclReferenceExprSyntax(baseName: "defaultValue")
+                            )
+                            InfixOperatorExprSyntax(
+                                leftOperand: MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                                    name: "table"
+                                ),
+                                operator: AssignmentExprSyntax(),
+                                rightOperand: DeclReferenceExprSyntax(baseName: "table")
+                            )
+                            InfixOperatorExprSyntax(
+                                leftOperand: MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                                    name: "locale"
+                                ),
+                                operator: AssignmentExprSyntax(),
+                                rightOperand: DeclReferenceExprSyntax(baseName: "locale")
+                            )
+                            InfixOperatorExprSyntax(
+                                leftOperand: MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                                    name: "bundle"
+                                ),
+                                operator: AssignmentExprSyntax(),
+                                rightOperand: DeclReferenceExprSyntax(baseName: "bundle")
+                            )
                         }
                     },
                     trailingTrivia: .newlines(2)
                 )
 
-                // Table accessor
-                VariableDeclSyntax(
-                    leadingTrivia: typeDocumentation,
+                // String initialiser
+                InitializerDeclSyntax(
                     modifiers: [
                         DeclModifierSyntax(name: accessLevel.token),
-                        DeclModifierSyntax(name: .keyword(.static))
                     ],
-                    .let,
-                    name: PatternSyntax(IdentifierPatternSyntax(identifier: variableToken)),
-                    initializer: InitializerClauseSyntax(
-                        value: FunctionCallExprSyntax(
-                            calledExpression: DeclReferenceExprSyntax(baseName: structToken),
-                            leftParen: .leftParenToken(),
-                            arguments: [],
-                            rightParen: .rightParenToken()
-                        )
+                    signature: FunctionSignatureSyntax(
+                        parameterClause: FunctionParameterClauseSyntax {
+                            FunctionParameterSyntax(
+                                firstName: variableToken,
+                                type: IdentifierTypeSyntax(name: structToken)
+                            )
+                        }
                     )
-                )
+                ) {
+                    FunctionCallExprSyntax(
+                        calledExpression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                            name: .keyword(.`init`)
+                        ),
+                        leftParen: .leftParenToken(),
+                        rightParen: .rightParenToken()
+                    ) {
+                        LabeledExprSyntax(
+                            label: "localized",
+                            expression: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: variableToken),
+                                name: "key"
+                            )
+                        )
+                        LabeledExprSyntax(
+                            label: "defaultValue",
+                            expression: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: variableToken),
+                                name: "defaultValue"
+                            )
+                        )
+                        LabeledExprSyntax(
+                            label: "table",
+                            expression: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: variableToken),
+                                name: "table"
+                            )
+                        )
+                        LabeledExprSyntax(
+                            label: "bundle",
+                            expression: FunctionCallExprSyntax(
+                                calledExpression: MemberAccessExprSyntax(
+                                    name: "from"
+                                ),
+                                leftParen: .leftParenToken(),
+                                rightParen: .rightParenToken()
+                            ) {
+                                LabeledExprSyntax(
+                                    label: "description",
+                                    expression: MemberAccessExprSyntax(
+                                        base: DeclReferenceExprSyntax(baseName: variableToken),
+                                        name: "bundle"
+                                    )
+                                )
+                            }
+                        )
+                        LabeledExprSyntax(
+                            label: "locale",
+                            expression: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: variableToken),
+                                name: "locale"
+                            )
+                        )
+                    }
+                }
             }
         )
+    }
+
+    func generateStringsTableExtension() -> ExtensionDeclSyntax {
+        ExtensionDeclSyntax(
+            attributes: [
+                .attribute(.init(availability: .wwdc2021))
+                    .with(\.trailingTrivia, .newline)
+            ],
+            extendedType: localTableMemberType
+        ) {
+            for resource in resources {
+                resource.declaration(
+                    tableName: tableName,
+                    variableToken: variableToken,
+                    accessLevel: accessLevel.token,
+                    isLocalizedStringResource: false
+                )
+            }
+        }
     }
 
     func generateBundleDescriptionExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
             attributes: [
-                .attribute(.init(availability: .wwdc2022))
+                .attribute(.init(availability: .wwdc2021))
                     .with(\.trailingTrivia, .newline)
             ],
             modifiers: [
                 DeclModifierSyntax(name: .keyword(.private))
             ],
-            extendedType: IdentifierTypeSyntax(name: "LocalizedStringResource.BundleDescription"),
+            extendedType: localBundleDescriptionMemberType,
             memberBlock: MemberBlockSyntax {
                 IfConfigDeclSyntax(
                     prefixOperator: "!",
@@ -153,6 +409,455 @@ public struct StringGenerator {
         )
     }
 
+    func generateBundleExtension() -> ExtensionDeclSyntax {
+        ExtensionDeclSyntax(
+            attributes: [
+                .attribute(.init(availability: .wwdc2021))
+                .with(\.trailingTrivia, .newline)
+            ],
+            modifiers: [
+                DeclModifierSyntax(name: .keyword(.private))
+            ],
+            extendedType: IdentifierTypeSyntax(name: "Bundle")
+        ) {
+            FunctionDeclSyntax(
+                modifiers: [
+                    DeclModifierSyntax(name: .keyword(.static))
+                ],
+                name: "from",
+                signature: FunctionSignatureSyntax(
+                    parameterClause: FunctionParameterClauseSyntax {
+                        FunctionParameterSyntax(
+                            firstName: "description",
+                            type: localBundleDescriptionMemberType
+                        )
+                    },
+                    returnClause: ReturnClauseSyntax(
+                        type: OptionalTypeSyntax(
+                            wrappedType: IdentifierTypeSyntax(name: "Bundle")
+                        )
+                    )
+                )
+            ) {
+                SwitchExprSyntax(
+                    subject: DeclReferenceExprSyntax(baseName: "description")
+                ) {
+                    // case .main:
+                    SwitchCaseSyntax(
+                        label: .case(
+                            SwitchCaseLabelSyntax(
+                                caseItems: SwitchCaseItemListSyntax {
+                                    SwitchCaseItemSyntax(
+                                        pattern: ExpressionPatternSyntax(
+                                            expression: MemberAccessExprSyntax(
+                                                declName: DeclReferenceExprSyntax(baseName: "main")
+                                            )
+                                        )
+                                    )
+                                }
+                            )
+                        ),
+                        statements: CodeBlockItemListSyntax {
+                            // Bundle.main
+                            MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: "Bundle"),
+                                name: "main"
+                            )
+                        }
+                    )
+
+                    // case .atURL(let url):
+                    SwitchCaseSyntax(
+                        label: .case(
+                            SwitchCaseLabelSyntax(
+                                caseItems: SwitchCaseItemListSyntax {
+                                    SwitchCaseItemSyntax(
+                                        pattern: ExpressionPatternSyntax(
+                                            expression: FunctionCallExprSyntax(
+                                                calledExpression: MemberAccessExprSyntax(
+                                                    declName: DeclReferenceExprSyntax(baseName: "atURL")
+                                                ),
+                                                leftParen: .leftParenToken(),
+                                                rightParen: .rightParenToken()
+                                            ) {
+                                                LabeledExprSyntax(
+                                                    expression: PatternExprSyntax(
+                                                        pattern: ValueBindingPatternSyntax(
+                                                            bindingSpecifier: .keyword(.let),
+                                                            pattern: IdentifierPatternSyntax(
+                                                                identifier: "url"
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            }
+                                        )
+                                    )
+                                }
+                            )
+                        ),
+                        statements: CodeBlockItemListSyntax {
+                            // Bundle(url: url)
+                            FunctionCallExprSyntax(
+                                calledExpression: DeclReferenceExprSyntax(
+                                    baseName: "Bundle"
+                                ),
+                                leftParen: .leftParenToken(),
+                                rightParen: .rightParenToken()
+                            ) {
+                                LabeledExprSyntax(
+                                    label: "url",
+                                    expression: DeclReferenceExprSyntax(
+                                        baseName: "url"
+                                    )
+                                )
+                            }
+                        }
+                    )
+
+                    // case .forClass(let anyClass):
+                    SwitchCaseSyntax(
+                        label: .case(
+                            SwitchCaseLabelSyntax(
+                                caseItems: SwitchCaseItemListSyntax {
+                                    SwitchCaseItemSyntax(
+                                        pattern: ExpressionPatternSyntax(
+                                            expression: FunctionCallExprSyntax(
+                                                calledExpression: MemberAccessExprSyntax(
+                                                    declName: DeclReferenceExprSyntax(baseName: "forClass")
+                                                ),
+                                                leftParen: .leftParenToken(),
+                                                rightParen: .rightParenToken()
+                                            ) {
+                                                LabeledExprSyntax(
+                                                    expression: PatternExprSyntax(
+                                                        pattern: ValueBindingPatternSyntax(
+                                                            bindingSpecifier: .keyword(.let),
+                                                            pattern: IdentifierPatternSyntax(
+                                                                identifier: "anyClass"
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            }
+                                        )
+                                    )
+                                }
+                            )
+                        ),
+                        statements: CodeBlockItemListSyntax {
+                            // Bundle(for: anyClass)
+                            FunctionCallExprSyntax(
+                                calledExpression: DeclReferenceExprSyntax(
+                                    baseName: "Bundle"
+                                ),
+                                leftParen: .leftParenToken(),
+                                rightParen: .rightParenToken()
+                            ) {
+                                LabeledExprSyntax(
+                                    label: "for",
+                                    expression: DeclReferenceExprSyntax(
+                                        baseName: "anyClass"
+                                    )
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    func generateFoundationBundleDescriptionExtension() -> ExtensionDeclSyntax {
+        ExtensionDeclSyntax(
+            attributes: [
+                .attribute(.init(availability: .wwdc2022))
+                .with(\.trailingTrivia, .newline)
+            ],
+            modifiers: [
+                DeclModifierSyntax(name: .keyword(.private))
+            ],
+            extendedType: localizedStringResourceBundleDescriptionMemberType
+        ) {
+            FunctionDeclSyntax(
+                modifiers: [
+                    DeclModifierSyntax(name: .keyword(.static))
+                ],
+                name: "from",
+                signature: FunctionSignatureSyntax(
+                    parameterClause: FunctionParameterClauseSyntax {
+                        FunctionParameterSyntax(
+                            firstName: "description",
+                            type: localBundleDescriptionMemberType
+                        )
+                    },
+                    returnClause: ReturnClauseSyntax(
+                        type: IdentifierTypeSyntax(name: .keyword(.Self))
+                    )
+                )
+            ) {
+                SwitchExprSyntax(
+                    subject: DeclReferenceExprSyntax(baseName: "description")
+                ) {
+                    // case .main:
+                    SwitchCaseSyntax(
+                        label: .case(
+                            SwitchCaseLabelSyntax(
+                                caseItems: SwitchCaseItemListSyntax {
+                                    SwitchCaseItemSyntax(
+                                        pattern: ExpressionPatternSyntax(
+                                            expression: MemberAccessExprSyntax(
+                                                declName: DeclReferenceExprSyntax(baseName: "main")
+                                            )
+                                        )
+                                    )
+                                }
+                            )
+                        ),
+                        statements: CodeBlockItemListSyntax {
+                            // .main
+                            MemberAccessExprSyntax(
+                                name: "main"
+                            )
+                        }
+                    )
+
+                    // case .atURL(let url):
+                    SwitchCaseSyntax(
+                        label: .case(
+                            SwitchCaseLabelSyntax(
+                                caseItems: SwitchCaseItemListSyntax {
+                                    SwitchCaseItemSyntax(
+                                        pattern: ExpressionPatternSyntax(
+                                            expression: FunctionCallExprSyntax(
+                                                calledExpression: MemberAccessExprSyntax(
+                                                    declName: DeclReferenceExprSyntax(baseName: "atURL")
+                                                ),
+                                                leftParen: .leftParenToken(),
+                                                rightParen: .rightParenToken()
+                                            ) {
+                                                LabeledExprSyntax(
+                                                    expression: PatternExprSyntax(
+                                                        pattern: ValueBindingPatternSyntax(
+                                                            bindingSpecifier: .keyword(.let),
+                                                            pattern: IdentifierPatternSyntax(
+                                                                identifier: "url"
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            }
+                                        )
+                                    )
+                                }
+                            )
+                        ),
+                        statements: CodeBlockItemListSyntax {
+                            // .atURL(url)
+                            FunctionCallExprSyntax(
+                                calledExpression: MemberAccessExprSyntax(
+                                    declName: DeclReferenceExprSyntax(
+                                        baseName: "atURL"
+                                    )
+                                ),
+                                leftParen: .leftParenToken(),
+                                rightParen: .rightParenToken()
+                            ) {
+                                LabeledExprSyntax(
+                                    expression: DeclReferenceExprSyntax(
+                                        baseName: "url"
+                                    )
+                                )
+                            }
+                        }
+                    )
+
+                    // case .forClass(let anyClass):
+                    SwitchCaseSyntax(
+                        label: .case(
+                            SwitchCaseLabelSyntax(
+                                caseItems: SwitchCaseItemListSyntax {
+                                    SwitchCaseItemSyntax(
+                                        pattern: ExpressionPatternSyntax(
+                                            expression: FunctionCallExprSyntax(
+                                                calledExpression: MemberAccessExprSyntax(
+                                                    declName: DeclReferenceExprSyntax(baseName: "forClass")
+                                                ),
+                                                leftParen: .leftParenToken(),
+                                                rightParen: .rightParenToken()
+                                            ) {
+                                                LabeledExprSyntax(
+                                                    expression: PatternExprSyntax(
+                                                        pattern: ValueBindingPatternSyntax(
+                                                            bindingSpecifier: .keyword(.let),
+                                                            pattern: IdentifierPatternSyntax(
+                                                                identifier: "anyClass"
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            }
+                                        )
+                                    )
+                                }
+                            )
+                        ),
+                        statements: CodeBlockItemListSyntax {
+                            // .forClass(anyClass)
+                            FunctionCallExprSyntax(
+                                calledExpression: MemberAccessExprSyntax(
+                                    declName: DeclReferenceExprSyntax(
+                                        baseName: "forClass"
+                                    )
+                                ),
+                                leftParen: .leftParenToken(),
+                                rightParen: .rightParenToken()
+                            ) {
+                                LabeledExprSyntax(
+                                    expression: DeclReferenceExprSyntax(
+                                        baseName: "anyClass"
+                                    )
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    func generateLocalizedStringResourceExtension() -> ExtensionDeclSyntax {
+        ExtensionDeclSyntax(
+            attributes: [
+                .attribute(.init(availability: .wwdc2022))
+                .with(\.trailingTrivia, .newline)
+            ],
+            extendedType: IdentifierTypeSyntax(name: "LocalizedStringResource")
+        ) {
+            // Table struct
+            StructDeclSyntax(
+//                leadingTrivia: typeDocumentation,
+                modifiers: [
+                    DeclModifierSyntax(name: accessLevel.token)
+                ],
+                name: structToken
+            ) {
+                for resource in resources {
+                    resource.declaration(
+                        tableName: tableName,
+                        variableToken: variableToken,
+                        accessLevel: accessLevel.token,
+                        isLocalizedStringResource: true
+                    )
+                }
+            }
+            .with(\.trailingTrivia, .newlines(2))
+
+            // Init
+            InitializerDeclSyntax(
+                modifiers: [
+                    DeclModifierSyntax(name: .keyword(.private))
+                ],
+                signature: FunctionSignatureSyntax(
+                    parameterClause: FunctionParameterClauseSyntax(
+                        leftParen: .leftParenToken(),
+                        rightParen: .rightParenToken()
+                    ) {
+                        FunctionParameterSyntax(
+                            firstName: variableToken,
+                            type: localTableMemberType
+                        )
+                    }
+                )
+            ) {
+                FunctionCallExprSyntax(
+                    calledExpression: MemberAccessExprSyntax(
+                        base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                        name: .keyword(.`init`)
+                    ),
+                    leftParen: .leftParenToken(),
+                    rightParen: .rightParenToken()
+                ) {
+                    LabeledExprSyntax(
+                        label: nil,
+                        expression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                            declName: DeclReferenceExprSyntax(baseName: "key")
+                        )
+                    )
+                    .with(\.trailingComma, .commaToken())
+
+                    LabeledExprSyntax(
+                        label: "defaultValue",
+                        expression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                            declName: DeclReferenceExprSyntax(baseName: "defaultValue")
+                        )
+                    )
+                    .with(\.trailingComma, .commaToken())
+
+                    LabeledExprSyntax(
+                        label: "table",
+                        expression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                            declName: DeclReferenceExprSyntax(baseName: "table")
+                        )
+                    )
+                    .with(\.trailingComma, .commaToken())
+
+                    LabeledExprSyntax(
+                        label: "locale",
+                        expression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                            declName: DeclReferenceExprSyntax(baseName: "locale")
+                        )
+                    )
+                    .with(\.trailingComma, .commaToken())
+
+                    LabeledExprSyntax(
+                        label: "bundle",
+                        colon: .colonToken(),
+                        expression: FunctionCallExprSyntax(
+                            calledExpression: MemberAccessExprSyntax(
+                                declName: DeclReferenceExprSyntax(baseName: "from")
+                            ),
+                            leftParen: .leftParenToken(),
+                            rightParen: .rightParenToken()
+                        ) {
+                            LabeledExprSyntax(
+                                label: "description",
+                                expression: MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: variableToken),
+                                    declName: DeclReferenceExprSyntax(baseName: "bundle")
+                                )
+                            )
+                        }
+                    )
+                }
+            }
+            .with(\.trailingTrivia, .newlines(2))
+
+            // Accessor
+            // internal static let localizable = Localizable()
+            VariableDeclSyntax(
+                modifiers: [
+                    DeclModifierSyntax(name: accessLevel.token),
+                    DeclModifierSyntax(name: .keyword(.static))
+                ],
+                .let,
+                name: PatternSyntax(IdentifierPatternSyntax(identifier: variableToken)),
+                initializer: InitializerClauseSyntax(
+                    value: FunctionCallExprSyntax(
+                        calledExpression: DeclReferenceExprSyntax(baseName: structToken),
+                        leftParen: .leftParenToken(),
+                        arguments: [],
+                        rightParen: .rightParenToken()
+                    )
+                )
+            )
+        }
+    }
+
     // MARK: - Helpers
 
     var typeDocumentation: Trivia {
@@ -185,14 +890,46 @@ public struct StringGenerator {
         ]
     }
 
+    // Localizable
     var structToken: TokenSyntax {
         .identifier(SwiftIdentifier.identifier(from: tableName))
     }
 
+    // bundleDescription
+    var bundleDescriptionNameToken: TokenSyntax {
+        .identifier(SwiftIdentifier.identifier(from: "BundleDescription"))
+    }
+
+    // String.Localizable
+    var localTableMemberType: MemberTypeSyntax {
+        MemberTypeSyntax(
+            baseType: IdentifierTypeSyntax(name: "String"),
+            name: structToken
+        )
+    }
+
+    // String.Localizable.BundleDescription
+    var localBundleDescriptionMemberType: MemberTypeSyntax {
+        MemberTypeSyntax(
+            baseType: localTableMemberType,
+            name: bundleDescriptionNameToken
+        )
+    }
+
+    // LocalizedStringResource.BundleDescription
+    var localizedStringResourceBundleDescriptionMemberType: MemberTypeSyntax {
+        MemberTypeSyntax(
+            baseType: IdentifierTypeSyntax(name: "LocalizedStringResource"),
+            name: bundleDescriptionNameToken
+        )
+    }
+
+    // localizable
     var variableToken: TokenSyntax {
         .identifier(SwiftIdentifier.variableIdentifier(for: tableName))
     }
 
+    // bundleDescription
     var bundleToken: TokenSyntax {
         .identifier("bundleDescription")
     }
@@ -211,21 +948,36 @@ extension StringGenerator.AccessLevel {
 extension Resource {
     func declaration(
         tableName: String,
-        accessLevel: TokenSyntax
+        variableToken: TokenSyntax,
+        accessLevel: TokenSyntax,
+        isLocalizedStringResource: Bool
     ) -> DeclSyntaxProtocol {
-        if arguments.isEmpty {
+        var modifiers = [DeclModifierSyntax(name: accessLevel)]
+        if !isLocalizedStringResource {
+            modifiers.append(DeclModifierSyntax(name: .keyword(.static)))
+        }
+
+        let type = if isLocalizedStringResource {
+            IdentifierTypeSyntax(name: "LocalizedStringResource")
+        } else {
+            IdentifierTypeSyntax(name: .keyword(.Self))
+        }
+
+        return if arguments.isEmpty {
             VariableDeclSyntax(
                 leadingTrivia: leadingTrivia,
-                modifiers: [
-                    DeclModifierSyntax(name: accessLevel)
-                ],
+                modifiers: .init(modifiers),
                 bindingSpecifier: .keyword(.var),
                 bindings: [
                     PatternBindingSyntax(
                         pattern: IdentifierPatternSyntax(identifier: name),
                         typeAnnotation: TypeAnnotationSyntax(type: type),
                         accessorBlock: AccessorBlockSyntax(
-                            accessors: .getter(statements(table: tableName))
+                            accessors: .getter(statements(
+                                table: tableName,
+                                variableToken: variableToken,
+                                isLocalizedStringResource: isLocalizedStringResource
+                            ))
                         )
                     )
                 ]
@@ -233,9 +985,7 @@ extension Resource {
         } else {
             FunctionDeclSyntax(
                 leadingTrivia: leadingTrivia,
-                modifiers: [
-                    DeclModifierSyntax(name: accessLevel)
-                ],
+                modifiers: .init(modifiers),
                 name: name,
                 signature: FunctionSignatureSyntax(
                     parameterClause: FunctionParameterClauseSyntax(
@@ -251,17 +1001,17 @@ extension Resource {
                     ),
                     returnClause: ReturnClauseSyntax(type: type)
                 ),
-                body: CodeBlockSyntax(statements: statements(table: tableName))
+                body: CodeBlockSyntax(statements: statements(
+                    table: tableName,
+                    variableToken: variableToken,
+                    isLocalizedStringResource: isLocalizedStringResource
+                ))
             )
         }
     }
 
     var name: TokenSyntax {
         .identifier(identifier)
-    }
-
-    var type: IdentifierTypeSyntax {
-        IdentifierTypeSyntax(name: .identifier("LocalizedStringResource"))
     }
 
     var leadingTrivia: Trivia {
@@ -277,46 +1027,81 @@ extension Resource {
         return trivia
     }
 
-    func statements(table: String) -> CodeBlockItemListSyntax {
+    func statements(
+        table: String,
+        variableToken: TokenSyntax,
+        isLocalizedStringResource: Bool
+    ) -> CodeBlockItemListSyntax {
         CodeBlockItemListSyntax {
-            CodeBlockItemSyntax(
-                item: .expr(
-                    ExprSyntax(
-                        FunctionCallExprSyntax(
-                            calledExpression: DeclReferenceExprSyntax(
-                                baseName: .identifier("LocalizedStringResource")
-                            ),
-                            leftParen: .leftParenToken(),
-                            arguments: [
-                                LabeledExprSyntax(label: nil, expression: keyExpr)
-                                    .with(\.trailingComma, .commaToken())
-                                    .with(\.leadingTrivia, .newline),
-                                
-                                LabeledExprSyntax(label: "defaultValue", expression: defaultValueExpr)
-                                    .with(\.trailingComma, .commaToken())
-                                    .with(\.leadingTrivia, .newline),
-                                
-                                LabeledExprSyntax(
-                                    label: "table",
-                                    expression: StringLiteralExprSyntax(content: table)
-                                )
-                                .with(\.trailingComma, .commaToken())
-                                .with(\.leadingTrivia, .newline),
+            if !isLocalizedStringResource {
+                FunctionCallExprSyntax(
+                    calledExpression: DeclReferenceExprSyntax(
+                        baseName: .keyword(.Self)
+                    ),
+                    leftParen: .leftParenToken(),
+                    rightParen: .rightParenToken(leadingTrivia: .newline)
+                ) {
+                    LabeledExprSyntax(label: "key", expression: keyExpr)
+                        .with(\.trailingComma, .commaToken())
+                        .with(\.leadingTrivia, .newline)
 
-                                LabeledExprSyntax(
-                                    label: "bundle",
-                                    expression: MemberAccessExprSyntax(
-                                        period: .periodToken(),
-                                        name: .identifier("current")
-                                    )
-                                )
-                                .with(\.leadingTrivia, .newline)
-                            ],
-                            rightParen: .rightParenToken(leadingTrivia: .newline)
+                    LabeledExprSyntax(label: "defaultValue", expression: defaultValueExpr)
+                        .with(\.trailingComma, .commaToken())
+                        .with(\.leadingTrivia, .newline)
+
+                    LabeledExprSyntax(
+                        label: "table",
+                        expression: StringLiteralExprSyntax(content: table)
+                    )
+                    .with(\.trailingComma, .commaToken())
+                    .with(\.leadingTrivia, .newline)
+
+                    LabeledExprSyntax(
+                        label: "locale",
+                        expression: MemberAccessExprSyntax(
+                            period: .periodToken(),
+                            name: .identifier("current")
                         )
                     )
-                )
-            )
+                    .with(\.trailingComma, .commaToken())
+                    .with(\.leadingTrivia, .newline)
+
+                    LabeledExprSyntax(
+                        label: "bundle",
+                        expression: MemberAccessExprSyntax(
+                            period: .periodToken(),
+                            name: .identifier("current")
+                        )
+                    )
+                    .with(\.leadingTrivia, .newline)
+                }
+            } else {
+                FunctionCallExprSyntax(
+                    calledExpression: DeclReferenceExprSyntax(baseName: "LocalizedStringResource"),
+                    leftParen: .leftParenToken(),
+                    rightParen: .rightParenToken()
+                ) {
+                    LabeledExprSyntax(
+                        label: variableToken.text,
+                        expression: FunctionCallExprSyntax(
+                            calledExpression: MemberAccessExprSyntax(
+                                declName: DeclReferenceExprSyntax(baseName: name)
+                            ),
+                            leftParen: arguments.isEmpty ? nil : .leftParenToken(),
+                            rightParen: arguments.isEmpty ? nil : .rightParenToken()
+                        ) {
+                            for argument in arguments {
+                                LabeledExprSyntax(
+                                    label: argument.label,
+                                    expression: DeclReferenceExprSyntax(
+                                        baseName: .identifier(argument.name)
+                                    )
+                                )
+                            }
+                        }
+                    )
+                }
+            }
         }
     }
 

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -34,27 +34,14 @@ public struct StringGenerator {
     func generate() -> SourceFileSyntax {
         SourceFileSyntax {
             generateImports()
-                .with(\.trailingTrivia, .newlines(2))
-
             generateStringExtension()
-                .with(\.trailingTrivia, .newlines(2))
-
             generateStringsTableExtension()
-                .with(\.trailingTrivia, .newlines(2))
-
             generateBundleDescriptionExtension()
-                .with(\.trailingTrivia, .newlines(2))
-
             generateBundleExtension()
-                .with(\.trailingTrivia, .newlines(2))
-
-            // iOS 16+ LocalisedStringResource
-
             generateFoundationBundleDescriptionExtension()
-                .with(\.trailingTrivia, .newlines(2))
-
             generateLocalizedStringResourceExtension()
         }
+        .spacingStatements()
     }
 
     // MARK: - Source File Contents
@@ -62,285 +49,254 @@ public struct StringGenerator {
     func generateImports() -> ImportDeclSyntax {
         ImportDeclSyntax(
             path: [
-                ImportPathComponentSyntax(name: .identifier("Foundation"))
+                ImportPathComponentSyntax(name: .import(.Foundation))
             ]
         )
     }
 
     func generateStringExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            attributes: [
-                .attribute(.init(availability: .wwdc2021))
-                    .with(\.trailingTrivia, .newline)
-            ],
-            extendedType: IdentifierTypeSyntax(name: "String"),
-            memberBlock: MemberBlockSyntax {
-                // Table struct
-                StructDeclSyntax(
-//                    leadingTrivia: typeDocumentation,
+            availability: .wwdc2021,
+            extendedType: .identifier(.String)
+        ) {
+            // Table struct
+            StructDeclSyntax(
+//                leadingTrivia: typeDocumentation,
+                modifiers: [
+                    DeclModifierSyntax(name: accessLevel.token)
+                ],
+                name: structToken
+            ) {
+                // BundleDescription
+                EnumDeclSyntax(
                     modifiers: [
                         DeclModifierSyntax(name: accessLevel.token)
                     ],
-                    name: structToken,
+                    name: .type(.BundleDescription),
                     memberBlockBuilder: {
-                        // BundleDescription
-                        EnumDeclSyntax(
-                            modifiers: [
-                                DeclModifierSyntax(name: accessLevel.token)
-                            ],
-                            name: bundleDescriptionNameToken,
-                            memberBlockBuilder: {
-                                EnumCaseDeclSyntax {
-                                    EnumCaseElementSyntax(name: .identifier("main"))
-                                }
-                                EnumCaseDeclSyntax {
-                                    EnumCaseElementSyntax(
-                                        name: .identifier("atURL"),
-                                        parameterClause: EnumCaseParameterClauseSyntax(
-                                            parameters: [
-                                                "URL"
-                                            ]
-                                        )
-                                    )
-                                }
-                                EnumCaseDeclSyntax {
-                                    EnumCaseElementSyntax(
-                                        name: .identifier("forClass"),
-                                        parameterClause: EnumCaseParameterClauseSyntax(
-                                            parameters: [
-                                                "AnyClass"
-                                            ]
-                                        )
-                                    )
-                                }
-                            },
-                            trailingTrivia: .newlines(2)
-                        )
-
-                        // Properties
-                        VariableDeclSyntax(
-                            modifiers: [
-                                DeclModifierSyntax(name: .keyword(.fileprivate)),
-                            ],
-                            .let,
-                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "key")),
-                            type: TypeAnnotationSyntax(
-                                type: IdentifierTypeSyntax(name: "StaticString")
-                            )
-                        )
-                        VariableDeclSyntax(
-                            modifiers: [
-                                DeclModifierSyntax(name: .keyword(.fileprivate)),
-                            ],
-                            .let,
-                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "defaultValue")),
-                            type: TypeAnnotationSyntax(
-                                type: IdentifierTypeSyntax(name: "LocalizationValue")
-                            )
-                        )
-                        VariableDeclSyntax(
-                            modifiers: [
-                                DeclModifierSyntax(name: .keyword(.fileprivate)),
-                            ],
-                            .let,
-                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "table")),
-                            type: TypeAnnotationSyntax(
-                                type: OptionalTypeSyntax(
-                                    wrappedType: IdentifierTypeSyntax(name: "String")
+                        EnumCaseDeclSyntax {
+                            EnumCaseElementSyntax(name: .identifier("main"))
+                        }
+                        EnumCaseDeclSyntax {
+                            EnumCaseElementSyntax(
+                                name: .identifier("atURL"),
+                                parameterClause: EnumCaseParameterClauseSyntax(
+                                    parameters: [
+                                        "URL"
+                                    ]
                                 )
                             )
-                        )
-                        VariableDeclSyntax(
-                            modifiers: [
-                                DeclModifierSyntax(name: .keyword(.fileprivate)),
-                            ],
-                            .let,
-                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "locale")),
-                            type: TypeAnnotationSyntax(
-                                type: IdentifierTypeSyntax(name: "Locale")
-                            )
-                        )
-                        VariableDeclSyntax(
-                            modifiers: [
-                                DeclModifierSyntax(name: .keyword(.fileprivate)),
-                            ],
-                            .let,
-                            name: PatternSyntax(IdentifierPatternSyntax(identifier: "bundle")),
-                            type: TypeAnnotationSyntax(
-                                type: IdentifierTypeSyntax(name: "BundleDescription")
-                            )
-                        ).with(\.trailingTrivia, .newlines(2))
-
-                        // Init
-                        InitializerDeclSyntax(
-                            modifiers: [
-                                DeclModifierSyntax(name: .keyword(.fileprivate)),
-                            ],
-                            signature: FunctionSignatureSyntax(
-                                parameterClause: FunctionParameterClauseSyntax {
-                                    FunctionParameterSyntax(
-                                        firstName: "key",
-                                        type: IdentifierTypeSyntax(name: "StaticString")
-                                    )
-                                    .with(\.trailingComma, .commaToken())
-                                    .with(\.leadingTrivia, .newline)
-
-                                    FunctionParameterSyntax(
-                                        firstName: "defaultValue",
-                                        type: IdentifierTypeSyntax(name: "LocalizationValue")
-                                    )
-                                    .with(\.trailingComma, .commaToken())
-                                    .with(\.leadingTrivia, .newline)
-
-                                    FunctionParameterSyntax(
-                                        firstName: "table",
-                                        type: OptionalTypeSyntax(
-                                            wrappedType: IdentifierTypeSyntax(name: "String")
-                                        )
-                                    )
-                                    .with(\.trailingComma, .commaToken())
-                                    .with(\.leadingTrivia, .newline)
-
-                                    FunctionParameterSyntax(
-                                        firstName: "locale",
-                                        type: IdentifierTypeSyntax(name: "Locale")
-                                    )
-                                    .with(\.trailingComma, .commaToken())
-                                    .with(\.leadingTrivia, .newline)
-
-                                    FunctionParameterSyntax(
-                                        firstName: "bundle",
-                                        type: IdentifierTypeSyntax(name: "BundleDescription")
-                                    )
-                                    .with(\.leadingTrivia, .newline)
-                                }
-                            )
-                        ) {
-                            InfixOperatorExprSyntax(
-                                leftOperand: MemberAccessExprSyntax(
-                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
-                                    name: "key"
-                                ),
-                                operator: AssignmentExprSyntax(),
-                                rightOperand: DeclReferenceExprSyntax(baseName: "key")
-                            )
-                            InfixOperatorExprSyntax(
-                                leftOperand: MemberAccessExprSyntax(
-                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
-                                    name: "defaultValue"
-                                ),
-                                operator: AssignmentExprSyntax(),
-                                rightOperand: DeclReferenceExprSyntax(baseName: "defaultValue")
-                            )
-                            InfixOperatorExprSyntax(
-                                leftOperand: MemberAccessExprSyntax(
-                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
-                                    name: "table"
-                                ),
-                                operator: AssignmentExprSyntax(),
-                                rightOperand: DeclReferenceExprSyntax(baseName: "table")
-                            )
-                            InfixOperatorExprSyntax(
-                                leftOperand: MemberAccessExprSyntax(
-                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
-                                    name: "locale"
-                                ),
-                                operator: AssignmentExprSyntax(),
-                                rightOperand: DeclReferenceExprSyntax(baseName: "locale")
-                            )
-                            InfixOperatorExprSyntax(
-                                leftOperand: MemberAccessExprSyntax(
-                                    base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
-                                    name: "bundle"
-                                ),
-                                operator: AssignmentExprSyntax(),
-                                rightOperand: DeclReferenceExprSyntax(baseName: "bundle")
+                        }
+                        EnumCaseDeclSyntax {
+                            EnumCaseElementSyntax(
+                                name: .identifier("forClass"),
+                                parameterClause: EnumCaseParameterClauseSyntax(
+                                    parameters: [
+                                        "AnyClass"
+                                    ]
+                                )
                             )
                         }
                     },
                     trailingTrivia: .newlines(2)
                 )
 
-                // String initialiser
+                // Properties
+                VariableDeclSyntax(
+                    modifiers: [
+                        DeclModifierSyntax(name: .keyword(.fileprivate)),
+                    ],
+                    .let,
+                    name: PatternSyntax(IdentifierPatternSyntax(identifier: "key")),
+                    type: TypeAnnotationSyntax(
+                        type: .identifier(.StaticString)
+                    )
+                )
+                VariableDeclSyntax(
+                    modifiers: [
+                        DeclModifierSyntax(name: .keyword(.fileprivate)),
+                    ],
+                    .let,
+                    name: PatternSyntax(IdentifierPatternSyntax(identifier: "defaultValue")),
+                    type: TypeAnnotationSyntax(type: .identifier(.LocalizationValue))
+                )
+                VariableDeclSyntax(
+                    modifiers: [
+                        DeclModifierSyntax(name: .keyword(.fileprivate)),
+                    ],
+                    .let,
+                    name: PatternSyntax(IdentifierPatternSyntax(identifier: "table")),
+                    type: TypeAnnotationSyntax(
+                        type: OptionalTypeSyntax(wrappedType: .identifier(.String))
+                    )
+                )
+                VariableDeclSyntax(
+                    modifiers: [
+                        DeclModifierSyntax(name: .keyword(.fileprivate)),
+                    ],
+                    .let,
+                    name: PatternSyntax(IdentifierPatternSyntax(identifier: "locale")),
+                    type: TypeAnnotationSyntax(type: .identifier(.Locale))
+                )
+                VariableDeclSyntax(
+                    modifiers: [
+                        DeclModifierSyntax(name: .keyword(.fileprivate)),
+                    ],
+                    .let,
+                    name: PatternSyntax(IdentifierPatternSyntax(identifier: "bundle")),
+                    type: TypeAnnotationSyntax(type: .identifier(.BundleDescription))
+                ).with(\.trailingTrivia, .newlines(2))
+
+                // Init
                 InitializerDeclSyntax(
                     modifiers: [
-                        DeclModifierSyntax(name: accessLevel.token),
+                        DeclModifierSyntax(name: .keyword(.fileprivate)),
                     ],
                     signature: FunctionSignatureSyntax(
                         parameterClause: FunctionParameterClauseSyntax {
                             FunctionParameterSyntax(
-                                firstName: variableToken,
-                                type: IdentifierTypeSyntax(name: structToken)
+                                firstName: "key",
+                                type: .identifier(.StaticString)
+                            )
+                            FunctionParameterSyntax(
+                                firstName: "defaultValue",
+                                type: .identifier(.LocalizationValue)
+                            )
+                            FunctionParameterSyntax(
+                                firstName: "table",
+                                type: OptionalTypeSyntax(wrappedType: .identifier(.String))
+                            )
+                            FunctionParameterSyntax(
+                                firstName: "locale",
+                                type: .identifier(.Locale)
+                            )
+                            FunctionParameterSyntax(
+                                firstName: "bundle",
+                                type: .identifier(.BundleDescription)
                             )
                         }
                     )
+                    .multiline()
                 ) {
-                    FunctionCallExprSyntax(
-                        calledExpression: MemberAccessExprSyntax(
+                    InfixOperatorExprSyntax(
+                        leftOperand: MemberAccessExprSyntax(
                             base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
-                            name: .keyword(.`init`)
+                            name: "key"
                         ),
-                        leftParen: .leftParenToken(),
-                        rightParen: .rightParenToken()
-                    ) {
-                        LabeledExprSyntax(
-                            label: "localized",
-                            expression: MemberAccessExprSyntax(
-                                base: DeclReferenceExprSyntax(baseName: variableToken),
-                                name: "key"
-                            )
-                        )
-                        LabeledExprSyntax(
-                            label: "defaultValue",
-                            expression: MemberAccessExprSyntax(
-                                base: DeclReferenceExprSyntax(baseName: variableToken),
-                                name: "defaultValue"
-                            )
-                        )
-                        LabeledExprSyntax(
-                            label: "table",
-                            expression: MemberAccessExprSyntax(
-                                base: DeclReferenceExprSyntax(baseName: variableToken),
-                                name: "table"
-                            )
-                        )
-                        LabeledExprSyntax(
-                            label: "bundle",
-                            expression: FunctionCallExprSyntax(
-                                calledExpression: MemberAccessExprSyntax(
-                                    name: "from"
-                                ),
-                                leftParen: .leftParenToken(),
-                                rightParen: .rightParenToken()
-                            ) {
-                                LabeledExprSyntax(
-                                    label: "description",
-                                    expression: MemberAccessExprSyntax(
-                                        base: DeclReferenceExprSyntax(baseName: variableToken),
-                                        name: "bundle"
-                                    )
-                                )
-                            }
-                        )
-                        LabeledExprSyntax(
-                            label: "locale",
-                            expression: MemberAccessExprSyntax(
-                                base: DeclReferenceExprSyntax(baseName: variableToken),
-                                name: "locale"
-                            )
-                        )
-                    }
+                        operator: AssignmentExprSyntax(),
+                        rightOperand: DeclReferenceExprSyntax(baseName: "key")
+                    )
+                    InfixOperatorExprSyntax(
+                        leftOperand: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                            name: "defaultValue"
+                        ),
+                        operator: AssignmentExprSyntax(),
+                        rightOperand: DeclReferenceExprSyntax(baseName: "defaultValue")
+                    )
+                    InfixOperatorExprSyntax(
+                        leftOperand: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                            name: "table"
+                        ),
+                        operator: AssignmentExprSyntax(),
+                        rightOperand: DeclReferenceExprSyntax(baseName: "table")
+                    )
+                    InfixOperatorExprSyntax(
+                        leftOperand: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                            name: "locale"
+                        ),
+                        operator: AssignmentExprSyntax(),
+                        rightOperand: DeclReferenceExprSyntax(baseName: "locale")
+                    )
+                    InfixOperatorExprSyntax(
+                        leftOperand: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                            name: "bundle"
+                        ),
+                        operator: AssignmentExprSyntax(),
+                        rightOperand: DeclReferenceExprSyntax(baseName: "bundle")
+                    )
                 }
             }
-        )
+
+            // String initialiser
+            InitializerDeclSyntax(
+                modifiers: [
+                    DeclModifierSyntax(name: accessLevel.token),
+                ],
+                signature: FunctionSignatureSyntax(
+                    parameterClause: FunctionParameterClauseSyntax {
+                        FunctionParameterSyntax(
+                            firstName: variableToken,
+                            type: IdentifierTypeSyntax(name: structToken)
+                        )
+                    }
+                )
+            ) {
+                FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(
+                        base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                        name: .keyword(.`init`)
+                    )
+                ) {
+                    LabeledExprSyntax(
+                        label: "localized",
+                        expression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                            name: "key"
+                        )
+                    )
+                    LabeledExprSyntax(
+                        label: "defaultValue",
+                        expression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                            name: "defaultValue"
+                        )
+                    )
+                    LabeledExprSyntax(
+                        label: "table",
+                        expression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                            name: "table"
+                        )
+                    )
+                    LabeledExprSyntax(
+                        label: "bundle",
+                        expression: FunctionCallExprSyntax(
+                            calledExpression: MemberAccessExprSyntax(
+                                name: "from"
+                            ),
+                            leftParen: .leftParenToken(),
+                            rightParen: .rightParenToken()
+                        ) {
+                            LabeledExprSyntax(
+                                label: "description",
+                                expression: MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: variableToken),
+                                    name: "bundle"
+                                )
+                            )
+                        }
+                    )
+                    LabeledExprSyntax(
+                        label: "locale",
+                        expression: MemberAccessExprSyntax(
+                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                            name: "locale"
+                        )
+                    )
+                }
+                .multiline()
+            }
+        }
+        .spacingMembers()
     }
 
     func generateStringsTableExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            attributes: [
-                .attribute(.init(availability: .wwdc2021))
-                    .with(\.trailingTrivia, .newline)
-            ],
+            availability: .wwdc2021,
             extendedType: localTableMemberType
         ) {
             for resource in resources {
@@ -352,73 +308,63 @@ public struct StringGenerator {
                 )
             }
         }
+        .spacingMembers()
     }
 
     func generateBundleDescriptionExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            attributes: [
-                .attribute(.init(availability: .wwdc2021))
-                    .with(\.trailingTrivia, .newline)
-            ],
-            modifiers: [
-                DeclModifierSyntax(name: .keyword(.private))
-            ],
-            extendedType: localBundleDescriptionMemberType,
-            memberBlock: MemberBlockSyntax {
-                IfConfigDeclSyntax(
-                    prefixOperator: "!",
-                    reference: "SWIFT_PACKAGE",
-                    elements: .decls([
-                        .init(decl: DeclSyntax("private class BundleLocator {}"))
-                    ])
-                )
-                .with(\.trailingTrivia, .newlines(2))
+            availability: .wwdc2021,
+            accessLevel: .private,
+            extendedType: localBundleDescriptionMemberType
+        ) {
+            IfConfigDeclSyntax(
+                prefixOperator: "!",
+                reference: "SWIFT_PACKAGE",
+                elements: .decls([
+                    .init(decl: DeclSyntax("private class BundleLocator {}"))
+                ])
+            )
 
-                VariableDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: .keyword(.static))
-                    ],
-                    bindingSpecifier: .keyword(.var),
-                    bindings: [
-                        PatternBindingSyntax(
-                            pattern: IdentifierPatternSyntax(identifier: "current"),
-                            typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: "Self")),
-                            accessorBlock: AccessorBlockSyntax(
-                                accessors: .getter([
-                                    CodeBlockItemSyntax(
-                                        item: .decl(
-                                            DeclSyntax(
-                                                IfConfigDeclSyntax(
-                                                    reference: "SWIFT_PACKAGE",
-                                                    elements: .statements([
-                                                        CodeBlockItemSyntax(item: .expr(ExprSyntax(".atURL(Bundle.module.bundleURL)")))
-                                                    ]),
-                                                    else: .statements([
-                                                        CodeBlockItemSyntax(item: .expr(ExprSyntax(".forClass(BundleLocator.self)")))
-                                                    ])
-                                                )
+            VariableDeclSyntax(
+                modifiers: [
+                    DeclModifierSyntax(name: .keyword(.static))
+                ],
+                bindingSpecifier: .keyword(.var),
+                bindings: [
+                    PatternBindingSyntax(
+                        pattern: IdentifierPatternSyntax(identifier: "current"),
+                        typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: "Self")),
+                        accessorBlock: AccessorBlockSyntax(
+                            accessors: .getter([
+                                CodeBlockItemSyntax(
+                                    item: .decl(
+                                        DeclSyntax(
+                                            IfConfigDeclSyntax(
+                                                reference: "SWIFT_PACKAGE",
+                                                elements: .statements([
+                                                    CodeBlockItemSyntax(item: .expr(ExprSyntax(".atURL(Bundle.module.bundleURL)")))
+                                                ]),
+                                                else: .statements([
+                                                    CodeBlockItemSyntax(item: .expr(ExprSyntax(".forClass(BundleLocator.self)")))
+                                                ])
                                             )
                                         )
                                     )
-                                ])
-                            )
+                                )
+                            ])
                         )
-                    ]
-                )
-            }
-        )
+                    )
+                ]
+            )
+        }
+        .spacingMembers()
     }
 
     func generateBundleExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            attributes: [
-                .attribute(.init(availability: .wwdc2021))
-                .with(\.trailingTrivia, .newline)
-            ],
-            modifiers: [
-                DeclModifierSyntax(name: .keyword(.private))
-            ],
-            extendedType: IdentifierTypeSyntax(name: "Bundle")
+            availability: .wwdc2021,
+            accessLevel: .private,
+            extendedType: .identifier(.Bundle)
         ) {
             FunctionDeclSyntax(
                 modifiers: [
@@ -434,7 +380,7 @@ public struct StringGenerator {
                     },
                     returnClause: ReturnClauseSyntax(
                         type: OptionalTypeSyntax(
-                            wrappedType: IdentifierTypeSyntax(name: "Bundle")
+                            wrappedType: .identifier(.Bundle)
                         )
                     )
                 )
@@ -460,7 +406,7 @@ public struct StringGenerator {
                         statements: CodeBlockItemListSyntax {
                             // Bundle.main
                             MemberAccessExprSyntax(
-                                base: DeclReferenceExprSyntax(baseName: "Bundle"),
+                                base: DeclReferenceExprSyntax(baseName: .type(.Bundle)),
                                 name: "main"
                             )
                         }
@@ -500,7 +446,7 @@ public struct StringGenerator {
                             // Bundle(url: url)
                             FunctionCallExprSyntax(
                                 calledExpression: DeclReferenceExprSyntax(
-                                    baseName: "Bundle"
+                                    baseName: .type(.Bundle)
                                 ),
                                 leftParen: .leftParenToken(),
                                 rightParen: .rightParenToken()
@@ -549,7 +495,7 @@ public struct StringGenerator {
                             // Bundle(for: anyClass)
                             FunctionCallExprSyntax(
                                 calledExpression: DeclReferenceExprSyntax(
-                                    baseName: "Bundle"
+                                    baseName: .type(.Bundle)
                                 ),
                                 leftParen: .leftParenToken(),
                                 rightParen: .rightParenToken()
@@ -566,17 +512,13 @@ public struct StringGenerator {
                 }
             }
         }
+        .spacingMembers()
     }
 
     func generateFoundationBundleDescriptionExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            attributes: [
-                .attribute(.init(availability: .wwdc2022))
-                .with(\.trailingTrivia, .newline)
-            ],
-            modifiers: [
-                DeclModifierSyntax(name: .keyword(.private))
-            ],
+            availability: .wwdc2022,
+            accessLevel: .private,
             extendedType: localizedStringResourceBundleDescriptionMemberType
         ) {
             FunctionDeclSyntax(
@@ -724,15 +666,13 @@ public struct StringGenerator {
                 }
             }
         }
+        .spacingMembers()
     }
 
     func generateLocalizedStringResourceExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            attributes: [
-                .attribute(.init(availability: .wwdc2022))
-                .with(\.trailingTrivia, .newline)
-            ],
-            extendedType: IdentifierTypeSyntax(name: "LocalizedStringResource")
+            availability: .wwdc2022,
+            extendedType: .identifier(.LocalizedStringResource)
         ) {
             // Table struct
             StructDeclSyntax(
@@ -751,7 +691,7 @@ public struct StringGenerator {
                     )
                 }
             }
-            .with(\.trailingTrivia, .newlines(2))
+            .spacingMembers()
 
             // Init
             InitializerDeclSyntax(
@@ -771,12 +711,10 @@ public struct StringGenerator {
                 )
             ) {
                 FunctionCallExprSyntax(
-                    calledExpression: MemberAccessExprSyntax(
+                    callee: MemberAccessExprSyntax(
                         base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
                         name: .keyword(.`init`)
-                    ),
-                    leftParen: .leftParenToken(),
-                    rightParen: .rightParenToken()
+                    )
                 ) {
                     LabeledExprSyntax(
                         label: nil,
@@ -785,7 +723,6 @@ public struct StringGenerator {
                             declName: DeclReferenceExprSyntax(baseName: "key")
                         )
                     )
-                    .with(\.trailingComma, .commaToken())
 
                     LabeledExprSyntax(
                         label: "defaultValue",
@@ -794,7 +731,6 @@ public struct StringGenerator {
                             declName: DeclReferenceExprSyntax(baseName: "defaultValue")
                         )
                     )
-                    .with(\.trailingComma, .commaToken())
 
                     LabeledExprSyntax(
                         label: "table",
@@ -803,7 +739,6 @@ public struct StringGenerator {
                             declName: DeclReferenceExprSyntax(baseName: "table")
                         )
                     )
-                    .with(\.trailingComma, .commaToken())
 
                     LabeledExprSyntax(
                         label: "locale",
@@ -812,11 +747,9 @@ public struct StringGenerator {
                             declName: DeclReferenceExprSyntax(baseName: "locale")
                         )
                     )
-                    .with(\.trailingComma, .commaToken())
 
                     LabeledExprSyntax(
                         label: "bundle",
-                        colon: .colonToken(),
                         expression: FunctionCallExprSyntax(
                             calledExpression: MemberAccessExprSyntax(
                                 declName: DeclReferenceExprSyntax(baseName: "from")
@@ -834,8 +767,8 @@ public struct StringGenerator {
                         }
                     )
                 }
+                .multiline()
             }
-            .with(\.trailingTrivia, .newlines(2))
 
             // Accessor
             // internal static let localizable = Localizable()
@@ -856,6 +789,7 @@ public struct StringGenerator {
                 )
             )
         }
+        .spacingMembers()
     }
 
     // MARK: - Helpers
@@ -895,15 +829,10 @@ public struct StringGenerator {
         .identifier(SwiftIdentifier.identifier(from: tableName))
     }
 
-    // bundleDescription
-    var bundleDescriptionNameToken: TokenSyntax {
-        .identifier(SwiftIdentifier.identifier(from: "BundleDescription"))
-    }
-
     // String.Localizable
     var localTableMemberType: MemberTypeSyntax {
         MemberTypeSyntax(
-            baseType: IdentifierTypeSyntax(name: "String"),
+            baseType: .identifier(.String),
             name: structToken
         )
     }
@@ -912,15 +841,15 @@ public struct StringGenerator {
     var localBundleDescriptionMemberType: MemberTypeSyntax {
         MemberTypeSyntax(
             baseType: localTableMemberType,
-            name: bundleDescriptionNameToken
+            name: .type(.BundleDescription)
         )
     }
 
     // LocalizedStringResource.BundleDescription
     var localizedStringResourceBundleDescriptionMemberType: MemberTypeSyntax {
         MemberTypeSyntax(
-            baseType: IdentifierTypeSyntax(name: "LocalizedStringResource"),
-            name: bundleDescriptionNameToken
+            baseType: .identifier(.LocalizedStringResource),
+            name: .type(.BundleDescription)
         )
     }
 
@@ -957,8 +886,8 @@ extension Resource {
             modifiers.append(DeclModifierSyntax(name: .keyword(.static)))
         }
 
-        let type = if isLocalizedStringResource {
-            IdentifierTypeSyntax(name: "LocalizedStringResource")
+        let type: IdentifierTypeSyntax = if isLocalizedStringResource {
+            .identifier(.LocalizedStringResource)
         } else {
             IdentifierTypeSyntax(name: .keyword(.Self))
         }
@@ -988,17 +917,11 @@ extension Resource {
                 modifiers: .init(modifiers),
                 name: name,
                 signature: FunctionSignatureSyntax(
-                    parameterClause: FunctionParameterClauseSyntax(
-                        parameters: FunctionParameterListSyntax {
-                            for (idx, argument) in zip(1..., arguments) {
-                                if idx == arguments.count {
-                                    argument.parameter
-                                } else {
-                                    argument.parameter.with(\.trailingComma, .commaToken())
-                                }
-                            }
+                    parameterClause: FunctionParameterClauseSyntax {
+                        for argument in arguments {
+                            argument.parameter
                         }
-                    ),
+                    }.commaSeparated(),
                     returnClause: ReturnClauseSyntax(type: type)
                 ),
                 body: CodeBlockSyntax(statements: statements(
@@ -1015,7 +938,7 @@ extension Resource {
     }
 
     var leadingTrivia: Trivia {
-        var trivia: Trivia = .newlines(2)
+        var trivia: Trivia = .init(pieces: [])
 
         if let commentLines = comment?.components(separatedBy: .newlines), !commentLines.isEmpty {
             for line in commentLines {
@@ -1035,60 +958,46 @@ extension Resource {
         CodeBlockItemListSyntax {
             if !isLocalizedStringResource {
                 FunctionCallExprSyntax(
-                    calledExpression: DeclReferenceExprSyntax(
+                    callee: DeclReferenceExprSyntax(
                         baseName: .keyword(.Self)
-                    ),
-                    leftParen: .leftParenToken(),
-                    rightParen: .rightParenToken(leadingTrivia: .newline)
+                    )
                 ) {
                     LabeledExprSyntax(label: "key", expression: keyExpr)
-                        .with(\.trailingComma, .commaToken())
-                        .with(\.leadingTrivia, .newline)
 
                     LabeledExprSyntax(label: "defaultValue", expression: defaultValueExpr)
-                        .with(\.trailingComma, .commaToken())
-                        .with(\.leadingTrivia, .newline)
 
                     LabeledExprSyntax(
                         label: "table",
                         expression: StringLiteralExprSyntax(content: table)
                     )
-                    .with(\.trailingComma, .commaToken())
-                    .with(\.leadingTrivia, .newline)
 
                     LabeledExprSyntax(
                         label: "locale",
                         expression: MemberAccessExprSyntax(
-                            period: .periodToken(),
                             name: .identifier("current")
                         )
                     )
-                    .with(\.trailingComma, .commaToken())
-                    .with(\.leadingTrivia, .newline)
 
                     LabeledExprSyntax(
                         label: "bundle",
                         expression: MemberAccessExprSyntax(
-                            period: .periodToken(),
                             name: .identifier("current")
                         )
                     )
-                    .with(\.leadingTrivia, .newline)
                 }
+                .multiline()
             } else {
                 FunctionCallExprSyntax(
-                    calledExpression: DeclReferenceExprSyntax(baseName: "LocalizedStringResource"),
-                    leftParen: .leftParenToken(),
-                    rightParen: .rightParenToken()
+                    callee: DeclReferenceExprSyntax(
+                        baseName: .type(.LocalizedStringResource)
+                    )
                 ) {
                     LabeledExprSyntax(
                         label: variableToken.text,
                         expression: FunctionCallExprSyntax(
-                            calledExpression: MemberAccessExprSyntax(
+                            callee: MemberAccessExprSyntax(
                                 declName: DeclReferenceExprSyntax(baseName: name)
-                            ),
-                            leftParen: arguments.isEmpty ? nil : .leftParenToken(),
-                            rightParen: arguments.isEmpty ? nil : .rightParenToken()
+                            )
                         ) {
                             for argument in arguments {
                                 LabeledExprSyntax(

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -995,9 +995,11 @@ extension Resource {
                     LabeledExprSyntax(
                         label: variableToken.text,
                         expression: FunctionCallExprSyntax(
-                            callee: MemberAccessExprSyntax(
+                            calledExpression: MemberAccessExprSyntax(
                                 declName: DeclReferenceExprSyntax(baseName: name)
-                            )
+                            ),
+                            leftParen: arguments.isEmpty ? nil : .leftParenToken(),
+                            rightParen: arguments.isEmpty ? nil : .rightParenToken()
                         ) {
                             for argument in arguments {
                                 LabeledExprSyntax(

--- a/Sources/StringGenerator/SwiftSyntax/AttributeSyntax+Availability.swift
+++ b/Sources/StringGenerator/SwiftSyntax/AttributeSyntax+Availability.swift
@@ -29,6 +29,24 @@ extension AvailabilityArgumentListSyntax {
             AvailabilityArgumentSyntax(argument: .token(.binaryOperator("*")))
         ]
     }
+
+    static var wwdc2021: AvailabilityArgumentListSyntax {
+        [
+            AvailabilityArgumentSyntax(argument: .platformVersionRestriction("macOS", versionMajor: 12))
+                .with(\.trailingComma, .commaToken()),
+
+            AvailabilityArgumentSyntax(argument: .platformVersionRestriction("iOS", versionMajor: 15))
+                .with(\.trailingComma, .commaToken()),
+
+            AvailabilityArgumentSyntax(argument: .platformVersionRestriction("tvOS", versionMajor: 15))
+                .with(\.trailingComma, .commaToken()),
+
+            AvailabilityArgumentSyntax(argument: .platformVersionRestriction("watchOS", versionMajor: 8))
+                .with(\.trailingComma, .commaToken()),
+
+            AvailabilityArgumentSyntax(argument: .token(.binaryOperator("*")))
+        ]
+    }
 }
 
 extension PlatformVersionSyntax {

--- a/Sources/StringGenerator/SwiftSyntax/ExtensionDeclSyntax.swift
+++ b/Sources/StringGenerator/SwiftSyntax/ExtensionDeclSyntax.swift
@@ -1,0 +1,33 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension ExtensionDeclSyntax {
+    init(
+        availability: AvailabilityArgumentListSyntax,
+        accessLevel: Keyword? = nil,
+        extendedType: some TypeSyntaxProtocol,
+        @MemberBlockItemListBuilder memberBlockBuilder: () -> MemberBlockItemListSyntax
+    ) {
+        self.init(
+            attributes: [
+                .attribute(
+                    AttributeSyntax(availability: availability)
+                        .with(\.trailingTrivia, .newline)
+                )
+            ],
+            modifiers: DeclModifierListSyntax {
+                if let accessLevel {
+                    DeclModifierSyntax(name: .keyword(accessLevel))
+                }
+            },
+            extendedType: extendedType,
+            memberBlock: MemberBlockSyntax(members: memberBlockBuilder())
+        )
+    }
+
+    func spacingMembers(_ lineCount: Int = 2) -> ExtensionDeclSyntax {
+        updating(\.memberBlock) { memberBlock in
+            memberBlock = memberBlock.spacingMembers(lineCount)
+        }
+    }
+}

--- a/Sources/StringGenerator/SwiftSyntax/FunctionCallExprSyntax.swift
+++ b/Sources/StringGenerator/SwiftSyntax/FunctionCallExprSyntax.swift
@@ -1,0 +1,22 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension FunctionCallExprSyntax {
+    func multiline() -> FunctionCallExprSyntax {
+        self
+            .updating(\.arguments) { arguments in
+                arguments = LabeledExprListSyntax {
+                    for (idx, argument) in zip(1..., arguments) {
+                        if idx == arguments.count {
+                            argument.with(\.leadingTrivia, .newline)
+                        } else {
+                            argument
+                                .with(\.trailingComma, .commaToken())
+                                .with(\.leadingTrivia, .newline)
+                        }
+                    }
+                }
+            }
+            .with(\.rightParen, .rightParenToken(leadingTrivia: .newline))
+    }
+}

--- a/Sources/StringGenerator/SwiftSyntax/FunctionSignatureSyntax.swift
+++ b/Sources/StringGenerator/SwiftSyntax/FunctionSignatureSyntax.swift
@@ -1,0 +1,38 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension FunctionSignatureSyntax {
+    func multiline() -> FunctionSignatureSyntax {
+        self
+            .updating(\.parameterClause) { $0 = $0.multiline() }
+    }
+}
+
+extension FunctionParameterClauseSyntax {
+    func multiline() -> FunctionParameterClauseSyntax {
+        self
+            .updating(\.parameters) { parameters in
+                parameters = FunctionParameterListSyntax {
+                    for parameter in parameters {
+                        parameter.with(\.leadingTrivia, .newline)
+                    }
+                }
+            }
+            .with(\.rightParen, .rightParenToken(leadingTrivia: .newline))
+    }
+
+    func commaSeparated() -> FunctionParameterClauseSyntax {
+        self.updating(\.parameters) { parameters in
+            parameters = FunctionParameterListSyntax {
+                for (idx, parameter) in zip(1..., parameters) {
+                    if idx == parameters.count {
+                        parameter
+                    } else {
+                        parameter
+                            .with(\.trailingComma, .commaToken())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/StringGenerator/SwiftSyntax/MemberBlockSyntax.swift
+++ b/Sources/StringGenerator/SwiftSyntax/MemberBlockSyntax.swift
@@ -1,0 +1,17 @@
+import SwiftSyntax
+
+extension MemberBlockSyntax {
+    func spacingMembers(_ lineCount: Int = 2) -> MemberBlockSyntax {
+        updating(\.members) { members in
+            members = MemberBlockItemListSyntax {
+                for (idx, item) in zip(1..., members) {
+                    if idx == members.count {
+                        item
+                    } else {
+                        item.with(\.trailingTrivia, .newlines(lineCount))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/StringGenerator/SwiftSyntax/SourceFileSyntax.swift
+++ b/Sources/StringGenerator/SwiftSyntax/SourceFileSyntax.swift
@@ -1,0 +1,18 @@
+import SwiftSyntax
+
+extension SourceFileSyntax {
+    func spacingStatements(_ lineCount: Int = 2) -> Self {
+        var copy = self
+        copy.statements = CodeBlockItemListSyntax {
+            for (idx, item) in zip(1..., statements) {
+                if idx == statements.count {
+                    item
+                } else {
+                    item.with(\.trailingTrivia, .newlines(lineCount))
+                }
+            }
+        }
+        return copy
+    }
+}
+

--- a/Sources/StringGenerator/SwiftSyntax/StructDeclSyntax.swift
+++ b/Sources/StringGenerator/SwiftSyntax/StructDeclSyntax.swift
@@ -1,0 +1,9 @@
+import SwiftSyntax
+
+extension StructDeclSyntax {
+    func spacingMembers(_ lineCount: Int = 2) -> StructDeclSyntax {
+        updating(\.memberBlock) { memberBlock in
+            memberBlock = memberBlock.spacingMembers(lineCount)
+        }
+    }
+}

--- a/Sources/StringGenerator/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/StringGenerator/SwiftSyntax/SyntaxProtocol.swift
@@ -1,0 +1,10 @@
+import SwiftSyntax
+
+public extension SyntaxProtocol {
+    /// Returns a new syntax node that has the child at `keyPath` updated by the changes closure
+    func updating<T>(_ keyPath: WritableKeyPath<Self, T>, changes: (inout T) -> Void) -> Self {
+        var copy = self
+        changes(&copy[keyPath: keyPath])
+        return copy
+    }
+}

--- a/Sources/StringGenerator/SwiftSyntax/TokenSyntax+Import.swift
+++ b/Sources/StringGenerator/SwiftSyntax/TokenSyntax+Import.swift
@@ -1,0 +1,11 @@
+import SwiftSyntax
+
+extension TokenSyntax {
+    enum Import: String {
+        case Foundation = "Foundation"
+    }
+
+    static func `import`(_ value: Import) -> TokenSyntax {
+        .identifier(value.rawValue)
+    }
+}

--- a/Sources/StringGenerator/SwiftSyntax/TokenSyntax+Types.swift
+++ b/Sources/StringGenerator/SwiftSyntax/TokenSyntax+Types.swift
@@ -1,0 +1,24 @@
+import SwiftSyntax
+
+extension TokenSyntax {
+    enum MetaType: String {
+        case String
+        case StaticString
+        case LocalizationValue
+        case Locale
+        case Bundle
+        case AnyClass
+        case BundleDescription
+        case LocalizedStringResource
+    }
+
+    static func type(_ value: MetaType) -> TokenSyntax {
+        .identifier(value.rawValue)
+    }
+}
+
+extension TypeSyntaxProtocol where Self == IdentifierTypeSyntax {
+    static func identifier(_ value: TokenSyntax.MetaType) -> IdentifierTypeSyntax {
+        IdentifierTypeSyntax(name: .type(value))
+    }
+}

--- a/Tests/PluginTests/PluginTests.swift
+++ b/Tests/PluginTests/PluginTests.swift
@@ -7,9 +7,20 @@ final class PluginTests: XCTestCase {
             String(localized: .localizable.demoBasic),
             "A basic string"
         )
+        XCTAssertEqual(
+            String(localizable: .demoBasic),
+            "A basic string"
+        )
 
         XCTAssertEqual(
             String(localized: .localizable.multiline(2)),
+            """
+            A string that
+            spans 2 lines
+            """
+        )
+        XCTAssertEqual(
+            String(localizable: .multiline(2)),
             """
             A string that
             spans 2 lines
@@ -20,9 +31,17 @@ final class PluginTests: XCTestCase {
             String(localized: .featureOne.pluralExample(1)),
             "1 string remaining"
         )
+        XCTAssertEqual(
+            String(featureOne: .pluralExample(1)),
+            "1 string remaining"
+        )
 
         XCTAssertEqual(
             String(localized: .featureOne.pluralExample(10)),
+            "10 strings remaining"
+        )
+        XCTAssertEqual(
+            String(featureOne: .pluralExample(10)),
             "10 strings remaining"
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -1,155 +1,183 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the FormatSpecifiers Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .formatSpecifiers.foo)
-    /// value // "bar"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.formatSpecifiers.foo)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     internal struct FormatSpecifiers {
-
-        /// %@ should convert to a String argument
-        internal func at(_ arg1: String) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "at",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
+        internal enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
         }
 
-        /// %c should convert to a CChar argument
-        internal func c(_ arg1: CChar) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "c",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
 
-        /// %d should convert to an Int argument
-        internal func d(_ arg1: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "d",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %lld should covert to an Int
-        internal func d_length(_ arg1: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "d_length",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %f should convert to a Double argument
-        internal func f(_ arg1: Double) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "f",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %.2f should convert to a Double argument
-        internal func f_precision(_ arg1: Double) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "f_precision",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %i should convert to an Int argument
-        internal func i(_ arg1: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "i",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %o should convert to a UInt argument
-        internal func o(_ arg1: UInt) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "o",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %p should convert to an UnsafeRawPointer argument
-        internal func p(_ arg1: UnsafeRawPointer) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "p",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %s should convert to an UnsafePointer<CChar> argument
-        internal func s(_ arg1: UnsafePointer<CChar>) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "s",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %u should convert to a UInt argument
-        internal func u(_ arg1: UInt) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "u",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
-        }
-
-        /// %x should convert to a UInt argument
-        internal func x(_ arg1: UInt) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "x",
-                defaultValue: ###"Test \###(arg1)"###,
-                table: "FormatSpecifiers",
-                bundle: .current
-            )
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the FormatSpecifiers Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .formatSpecifiers.foo)
-    /// value // "bar"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.formatSpecifiers.foo)
-    /// ```
-    internal static let formatSpecifiers = FormatSpecifiers()
+    internal init(formatSpecifiers: FormatSpecifiers) {
+        self.init(
+            localized: formatSpecifiers.key,
+            defaultValue: formatSpecifiers.defaultValue,
+            table: formatSpecifiers.table,
+            bundle: .from(description: formatSpecifiers.bundle),
+            locale: formatSpecifiers.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.FormatSpecifiers {
+    /// %@ should convert to a String argument
+    internal static func at(_ arg1: String) -> Self {
+        Self (
+            key: "at",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %c should convert to a CChar argument
+    internal static func c(_ arg1: CChar) -> Self {
+        Self (
+            key: "c",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %d should convert to an Int argument
+    internal static func d(_ arg1: Int) -> Self {
+        Self (
+            key: "d",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %lld should covert to an Int
+    internal static func d_length(_ arg1: Int) -> Self {
+        Self (
+            key: "d_length",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %f should convert to a Double argument
+    internal static func f(_ arg1: Double) -> Self {
+        Self (
+            key: "f",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %.2f should convert to a Double argument
+    internal static func f_precision(_ arg1: Double) -> Self {
+        Self (
+            key: "f_precision",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %i should convert to an Int argument
+    internal static func i(_ arg1: Int) -> Self {
+        Self (
+            key: "i",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %o should convert to a UInt argument
+    internal static func o(_ arg1: UInt) -> Self {
+        Self (
+            key: "o",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %p should convert to an UnsafeRawPointer argument
+    internal static func p(_ arg1: UnsafeRawPointer) -> Self {
+        Self (
+            key: "p",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %s should convert to an UnsafePointer<CChar> argument
+    internal static func s(_ arg1: UnsafePointer<CChar>) -> Self {
+        Self (
+            key: "s",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %u should convert to a UInt argument
+    internal static func u(_ arg1: UInt) -> Self {
+        Self (
+            key: "u",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// %x should convert to a UInt argument
+    internal static func x(_ arg1: UInt) -> Self {
+        Self (
+            key: "x",
+            defaultValue: ###"Test \###(arg1)"###,
+            table: "FormatSpecifiers",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.FormatSpecifiers.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -162,4 +190,109 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.FormatSpecifiers.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.FormatSpecifiers.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    internal struct FormatSpecifiers {
+        /// %@ should convert to a String argument
+        internal func at(_ arg1: String) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .at(arg1))
+        }
+
+        /// %c should convert to a CChar argument
+        internal func c(_ arg1: CChar) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .c(arg1))
+        }
+
+        /// %d should convert to an Int argument
+        internal func d(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .d(arg1))
+        }
+
+        /// %lld should covert to an Int
+        internal func d_length(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .d_length(arg1))
+        }
+
+        /// %f should convert to a Double argument
+        internal func f(_ arg1: Double) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .f(arg1))
+        }
+
+        /// %.2f should convert to a Double argument
+        internal func f_precision(_ arg1: Double) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .f_precision(arg1))
+        }
+
+        /// %i should convert to an Int argument
+        internal func i(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .i(arg1))
+        }
+
+        /// %o should convert to a UInt argument
+        internal func o(_ arg1: UInt) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .o(arg1))
+        }
+
+        /// %p should convert to an UnsafeRawPointer argument
+        internal func p(_ arg1: UnsafeRawPointer) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .p(arg1))
+        }
+
+        /// %s should convert to an UnsafePointer<CChar> argument
+        internal func s(_ arg1: UnsafePointer<CChar>) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .s(arg1))
+        }
+
+        /// %u should convert to a UInt argument
+        internal func u(_ arg1: UInt) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .u(arg1))
+        }
+
+        /// %x should convert to a UInt argument
+        internal func x(_ arg1: UInt) -> LocalizedStringResource {
+            LocalizedStringResource(formatSpecifiers: .x(arg1))
+        }
+    }
+
+    private init(formatSpecifiers: String.FormatSpecifiers) {
+        self.init(
+            formatSpecifiers.key,
+            defaultValue: formatSpecifiers.defaultValue,
+            table: formatSpecifiers.table,
+            locale: formatSpecifiers.locale,
+            bundle: .from(description: formatSpecifiers.bundle)
+        )
+    }
+
+    internal static let formatSpecifiers = FormatSpecifiers()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the FormatSpecifiers Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(formatSpecifiers: .foo)
+    /// value // "bar"
+    /// ```
     internal struct FormatSpecifiers {
         fileprivate enum BundleDescription {
             case main
@@ -222,6 +229,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the FormatSpecifiers Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .formatSpecifiers.foo)
+    /// value // "bar"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.formatSpecifiers.foo)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.FormatSpecifiers`` requires iOS 16/macOS 13 or later. See ``String.FormatSpecifiers`` for an iOS 15/macOS 12 compatible API.
     internal struct FormatSpecifiers {
         /// %@ should convert to a String argument
         internal func at(_ arg1: String) -> LocalizedStringResource {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     internal struct FormatSpecifiers {
-        internal enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -1,72 +1,92 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the Localizable Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .localizable.key)
-    /// value // "Default Value"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.localizable.key)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     internal struct Localizable {
-
-        /// This is a comment
-        internal var key: LocalizedStringResource {
-            LocalizedStringResource(
-                "Key",
-                defaultValue: ###"Default Value"###,
-                table: "Localizable",
-                bundle: .current
-            )
+        internal enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
         }
 
-        internal var myDeviceVariant: LocalizedStringResource {
-            LocalizedStringResource(
-                "myDeviceVariant",
-                defaultValue: ###"Multiplatform Original"###,
-                table: "Localizable",
-                bundle: .current
-            )
-        }
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
 
-        internal func myPlural(_ arg1: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "myPlural",
-                defaultValue: ###"I have \###(arg1) plurals"###,
-                table: "Localizable",
-                bundle: .current
-            )
-        }
-
-        internal func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "mySubstitute",
-                defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
-                table: "Localizable",
-                bundle: .current
-            )
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the Localizable Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .localizable.key)
-    /// value // "Default Value"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.localizable.key)
-    /// ```
-    internal static let localizable = Localizable()
+    internal init(localizable: Localizable) {
+        self.init(
+            localized: localizable.key,
+            defaultValue: localizable.defaultValue,
+            table: localizable.table,
+            bundle: .from(description: localizable.bundle),
+            locale: localizable.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Localizable {
+    /// This is a comment
+    internal static var key: Self {
+        Self (
+            key: "Key",
+            defaultValue: ###"Default Value"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    internal static var myDeviceVariant: Self {
+        Self (
+            key: "myDeviceVariant",
+            defaultValue: ###"Multiplatform Original"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    internal static func myPlural(_ arg1: Int) -> Self {
+        Self (
+            key: "myPlural",
+            defaultValue: ###"I have \###(arg1) plurals"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    internal static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
+        Self (
+            key: "mySubstitute",
+            defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Localizable.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -79,4 +99,66 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.Localizable.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.Localizable.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    internal struct Localizable {
+        /// This is a comment
+        internal var key: LocalizedStringResource {
+            LocalizedStringResource(localizable: .key)
+        }
+
+        internal var myDeviceVariant: LocalizedStringResource {
+            LocalizedStringResource(localizable: .myDeviceVariant)
+        }
+
+        internal func myPlural(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(localizable: .myPlural(arg1))
+        }
+
+        internal func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
+            LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
+        }
+    }
+
+    private init(localizable: String.Localizable) {
+        self.init(
+            localizable.key,
+            defaultValue: localizable.defaultValue,
+            table: localizable.table,
+            locale: localizable.locale,
+            bundle: .from(description: localizable.bundle)
+        )
+    }
+
+    internal static let localizable = Localizable()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the Localizable Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localizable: .key)
+    /// value // "Default Value"
+    /// ```
     internal struct Localizable {
         fileprivate enum BundleDescription {
             case main
@@ -131,6 +138,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the Localizable Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .localizable.key)
+    /// value // "Default Value"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.localizable.key)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
     internal struct Localizable {
         /// This is a comment
         internal var key: LocalizedStringResource {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     internal struct Localizable {
-        internal enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -1,47 +1,64 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the Multiline Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .multiline.multiline)
-    /// value // "Options:\n- One\n- Two\n- Three"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.multiline.multiline)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     internal struct Multiline {
+        internal enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
+        }
 
-        /// This example tests the following:
-        /// 1. That line breaks in the defaultValue are supported
-        /// 2. That line breaks in the comment are supported
-        internal var multiline: LocalizedStringResource {
-            LocalizedStringResource(
-                "multiline",
-                defaultValue: ###"Options:\###n- One\###n- Two\###n- Three"###,
-                table: "Multiline",
-                bundle: .current
-            )
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
+
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the Multiline Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .multiline.multiline)
-    /// value // "Options:\n- One\n- Two\n- Three"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.multiline.multiline)
-    /// ```
-    internal static let multiline = Multiline()
+    internal init(multiline: Multiline) {
+        self.init(
+            localized: multiline.key,
+            defaultValue: multiline.defaultValue,
+            table: multiline.table,
+            bundle: .from(description: multiline.bundle),
+            locale: multiline.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Multiline {
+    /// This example tests the following:
+    /// 1. That line breaks in the defaultValue are supported
+    /// 2. That line breaks in the comment are supported
+    internal static var multiline: Self {
+        Self (
+            key: "multiline",
+            defaultValue: ###"Options:\###n- One\###n- Two\###n- Three"###,
+            table: "Multiline",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Multiline.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -54,4 +71,56 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.Multiline.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.Multiline.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    internal struct Multiline {
+        /// This example tests the following:
+        /// 1. That line breaks in the defaultValue are supported
+        /// 2. That line breaks in the comment are supported
+        internal var multiline: LocalizedStringResource {
+            LocalizedStringResource(multiline: .multiline)
+        }
+    }
+
+    private init(multiline: String.Multiline) {
+        self.init(
+            multiline.key,
+            defaultValue: multiline.defaultValue,
+            table: multiline.table,
+            locale: multiline.locale,
+            bundle: .from(description: multiline.bundle)
+        )
+    }
+
+    internal static let multiline = Multiline()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the Multiline Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(multiline: .multiline)
+    /// value // "Options:\n- One\n- Two\n- Three"
+    /// ```
     internal struct Multiline {
         fileprivate enum BundleDescription {
             case main
@@ -103,6 +110,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the Multiline Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .multiline.multiline)
+    /// value // "Options:\n- One\n- Two\n- Three"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.multiline.multiline)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.Multiline`` requires iOS 16/macOS 13 or later. See ``String.Multiline`` for an iOS 15/macOS 12 compatible API.
     internal struct Multiline {
         /// This example tests the following:
         /// 1. That line breaks in the defaultValue are supported

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     internal struct Multiline {
-        internal enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     internal struct Positional {
-        internal enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -1,65 +1,84 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the Positional Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .positional.foo)
-    /// value // "bar"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.positional.foo)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     internal struct Positional {
-
-        /// A string where the second argument is at the front of the string and the first argument is at the end
-        internal func reorder(_ arg1: Int, _ arg2: String) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "reorder",
-                defaultValue: ###"Second: \###(arg2) - First: \###(arg1)"###,
-                table: "Positional",
-                bundle: .current
-            )
+        internal enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
         }
 
-        /// A string that uses the same argument twice
-        internal func repeatExplicit(_ arg1: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "repeatExplicit",
-                defaultValue: ###"\###(arg1), I repeat: \###(arg1)"###,
-                table: "Positional",
-                bundle: .current
-            )
-        }
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
 
-        /// A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance
-        internal func repeatImplicit(_ arg1: String) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "repeatImplicit",
-                defaultValue: ###"\###(arg1), are you there? \###(arg1)?"###,
-                table: "Positional",
-                bundle: .current
-            )
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the Positional Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .positional.foo)
-    /// value // "bar"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.positional.foo)
-    /// ```
-    internal static let positional = Positional()
+    internal init(positional: Positional) {
+        self.init(
+            localized: positional.key,
+            defaultValue: positional.defaultValue,
+            table: positional.table,
+            bundle: .from(description: positional.bundle),
+            locale: positional.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Positional {
+    /// A string where the second argument is at the front of the string and the first argument is at the end
+    internal static func reorder(_ arg1: Int, _ arg2: String) -> Self {
+        Self (
+            key: "reorder",
+            defaultValue: ###"Second: \###(arg2) - First: \###(arg1)"###,
+            table: "Positional",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// A string that uses the same argument twice
+    internal static func repeatExplicit(_ arg1: Int) -> Self {
+        Self (
+            key: "repeatExplicit",
+            defaultValue: ###"\###(arg1), I repeat: \###(arg1)"###,
+            table: "Positional",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    /// A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance
+    internal static func repeatImplicit(_ arg1: String) -> Self {
+        Self (
+            key: "repeatImplicit",
+            defaultValue: ###"\###(arg1), are you there? \###(arg1)?"###,
+            table: "Positional",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Positional.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -72,4 +91,64 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.Positional.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.Positional.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    internal struct Positional {
+        /// A string where the second argument is at the front of the string and the first argument is at the end
+        internal func reorder(_ arg1: Int, _ arg2: String) -> LocalizedStringResource {
+            LocalizedStringResource(positional: .reorder(arg1, arg2))
+        }
+
+        /// A string that uses the same argument twice
+        internal func repeatExplicit(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(positional: .repeatExplicit(arg1))
+        }
+
+        /// A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance
+        internal func repeatImplicit(_ arg1: String) -> LocalizedStringResource {
+            LocalizedStringResource(positional: .repeatImplicit(arg1))
+        }
+    }
+
+    private init(positional: String.Positional) {
+        self.init(
+            positional.key,
+            defaultValue: positional.defaultValue,
+            table: positional.table,
+            locale: positional.locale,
+            bundle: .from(description: positional.bundle)
+        )
+    }
+
+    internal static let positional = Positional()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the Positional Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(positional: .foo)
+    /// value // "bar"
+    /// ```
     internal struct Positional {
         fileprivate enum BundleDescription {
             case main
@@ -123,6 +130,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the Positional Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .positional.foo)
+    /// value // "bar"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.positional.foo)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.Positional`` requires iOS 16/macOS 13 or later. See ``String.Positional`` for an iOS 15/macOS 12 compatible API.
     internal struct Positional {
         /// A string where the second argument is at the front of the string and the first argument is at the end
         internal func reorder(_ arg1: Int, _ arg2: String) -> LocalizedStringResource {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -1,45 +1,62 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the Simple Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .simple.simpleKey)
-    /// value // "My Value"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.simple.simpleKey)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     internal struct Simple {
+        internal enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
+        }
 
-        /// This is a simple key and value
-        internal var simpleKey: LocalizedStringResource {
-            LocalizedStringResource(
-                "SimpleKey",
-                defaultValue: ###"My Value"###,
-                table: "Simple",
-                bundle: .current
-            )
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
+
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the Simple Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .simple.simpleKey)
-    /// value // "My Value"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.simple.simpleKey)
-    /// ```
-    internal static let simple = Simple()
+    internal init(simple: Simple) {
+        self.init(
+            localized: simple.key,
+            defaultValue: simple.defaultValue,
+            table: simple.table,
+            bundle: .from(description: simple.bundle),
+            locale: simple.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Simple {
+    /// This is a simple key and value
+    internal static var simpleKey: Self {
+        Self (
+            key: "SimpleKey",
+            defaultValue: ###"My Value"###,
+            table: "Simple",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Simple.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -52,4 +69,54 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.Simple.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.Simple.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    internal struct Simple {
+        /// This is a simple key and value
+        internal var simpleKey: LocalizedStringResource {
+            LocalizedStringResource(simple: .simpleKey)
+        }
+    }
+
+    private init(simple: String.Simple) {
+        self.init(
+            simple.key,
+            defaultValue: simple.defaultValue,
+            table: simple.table,
+            locale: simple.locale,
+            bundle: .from(description: simple.bundle)
+        )
+    }
+
+    internal static let simple = Simple()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     internal struct Simple {
-        internal enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the Simple Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(simple: .simpleKey)
+    /// value // "My Value"
+    /// ```
     internal struct Simple {
         fileprivate enum BundleDescription {
             case main
@@ -101,6 +108,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the Simple Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .simple.simpleKey)
+    /// value // "My Value"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.simple.simpleKey)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.Simple`` requires iOS 16/macOS 13 or later. See ``String.Simple`` for an iOS 15/macOS 12 compatible API.
     internal struct Simple {
         /// This is a simple key and value
         internal var simpleKey: LocalizedStringResource {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -1,45 +1,62 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the Substitution Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .substitution.foo)
-    /// value // "bar"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.substitution.foo)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     internal struct Substitution {
+        internal enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
+        }
 
-        /// A string that uses substitutions as well as arguments
-        internal func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "substitutions_example.string",
-                defaultValue: ###"\###(arg1)! There are \###(arg2) strings and you have \###(arg3) remaining"###,
-                table: "Substitution",
-                bundle: .current
-            )
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
+
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the Substitution Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .substitution.foo)
-    /// value // "bar"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.substitution.foo)
-    /// ```
-    internal static let substitution = Substitution()
+    internal init(substitution: Substitution) {
+        self.init(
+            localized: substitution.key,
+            defaultValue: substitution.defaultValue,
+            table: substitution.table,
+            bundle: .from(description: substitution.bundle),
+            locale: substitution.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Substitution {
+    /// A string that uses substitutions as well as arguments
+    internal static func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> Self {
+        Self (
+            key: "substitutions_example.string",
+            defaultValue: ###"\###(arg1)! There are \###(arg2) strings and you have \###(arg3) remaining"###,
+            table: "Substitution",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Substitution.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -52,4 +69,54 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.Substitution.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.Substitution.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    internal struct Substitution {
+        /// A string that uses substitutions as well as arguments
+        internal func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> LocalizedStringResource {
+            LocalizedStringResource(substitution: .substitutions_exampleString(arg1, totalStrings: arg2, remainingStrings: arg3))
+        }
+    }
+
+    private init(substitution: String.Substitution) {
+        self.init(
+            substitution.key,
+            defaultValue: substitution.defaultValue,
+            table: substitution.table,
+            locale: substitution.locale,
+            bundle: .from(description: substitution.bundle)
+        )
+    }
+
+    internal static let substitution = Substitution()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the Substitution Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(substitution: .foo)
+    /// value // "bar"
+    /// ```
     internal struct Substitution {
         fileprivate enum BundleDescription {
             case main
@@ -101,6 +108,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the Substitution Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .substitution.foo)
+    /// value // "bar"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.substitution.foo)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.Substitution`` requires iOS 16/macOS 13 or later. See ``String.Substitution`` for an iOS 15/macOS 12 compatible API.
     internal struct Substitution {
         /// A string that uses substitutions as well as arguments
         internal func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> LocalizedStringResource {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     internal struct Substitution {
-        internal enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     internal struct Variations {
-        internal enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the Variations Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(variations: .stringDevice)
+    /// value // "Tap to open"
+    /// ```
     internal struct Variations {
         fileprivate enum BundleDescription {
             case main
@@ -111,6 +118,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the Variations Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .variations.stringDevice)
+    /// value // "Tap to open"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.variations.stringDevice)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.Variations`` requires iOS 16/macOS 13 or later. See ``String.Variations`` for an iOS 15/macOS 12 compatible API.
     internal struct Variations {
         /// A string that should have a macOS variation to replace 'Tap' with 'Click'
         internal var stringDevice: LocalizedStringResource {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -1,54 +1,72 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the Variations Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .variations.stringDevice)
-    /// value // "Tap to open"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.variations.stringDevice)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     internal struct Variations {
-
-        /// A string that should have a macOS variation to replace 'Tap' with 'Click'
-        internal var stringDevice: LocalizedStringResource {
-            LocalizedStringResource(
-                "String.Device",
-                defaultValue: ###"Tap to open"###,
-                table: "Variations",
-                bundle: .current
-            )
+        internal enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
         }
 
-        internal func stringPlural(_ arg1: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "String.Plural",
-                defaultValue: ###"I have \###(arg1) strings"###,
-                table: "Variations",
-                bundle: .current
-            )
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
+
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the Variations Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .variations.stringDevice)
-    /// value // "Tap to open"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.variations.stringDevice)
-    /// ```
-    internal static let variations = Variations()
+    internal init(variations: Variations) {
+        self.init(
+            localized: variations.key,
+            defaultValue: variations.defaultValue,
+            table: variations.table,
+            bundle: .from(description: variations.bundle),
+            locale: variations.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Variations {
+    /// A string that should have a macOS variation to replace 'Tap' with 'Click'
+    internal static var stringDevice: Self {
+        Self (
+            key: "String.Device",
+            defaultValue: ###"Tap to open"###,
+            table: "Variations",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    internal static func stringPlural(_ arg1: Int) -> Self {
+        Self (
+            key: "String.Plural",
+            defaultValue: ###"I have \###(arg1) strings"###,
+            table: "Variations",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Variations.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -61,4 +79,58 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.Variations.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.Variations.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    internal struct Variations {
+        /// A string that should have a macOS variation to replace 'Tap' with 'Click'
+        internal var stringDevice: LocalizedStringResource {
+            LocalizedStringResource(variations: .stringDevice)
+        }
+
+        internal func stringPlural(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(variations: .stringPlural(arg1))
+        }
+    }
+
+    private init(variations: String.Variations) {
+        self.init(
+            variations.key,
+            defaultValue: variations.defaultValue,
+            table: variations.table,
+            locale: variations.locale,
+            bundle: .from(description: variations.bundle)
+        )
+    }
+
+    internal static let variations = Variations()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -1,72 +1,92 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the Localizable Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .localizable.key)
-    /// value // "Default Value"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.localizable.key)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     package struct Localizable {
-
-        /// This is a comment
-        package var key: LocalizedStringResource {
-            LocalizedStringResource(
-                "Key",
-                defaultValue: ###"Default Value"###,
-                table: "Localizable",
-                bundle: .current
-            )
+        package enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
         }
 
-        package var myDeviceVariant: LocalizedStringResource {
-            LocalizedStringResource(
-                "myDeviceVariant",
-                defaultValue: ###"Multiplatform Original"###,
-                table: "Localizable",
-                bundle: .current
-            )
-        }
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
 
-        package func myPlural(_ arg1: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "myPlural",
-                defaultValue: ###"I have \###(arg1) plurals"###,
-                table: "Localizable",
-                bundle: .current
-            )
-        }
-
-        package func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "mySubstitute",
-                defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
-                table: "Localizable",
-                bundle: .current
-            )
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the Localizable Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .localizable.key)
-    /// value // "Default Value"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.localizable.key)
-    /// ```
-    package static let localizable = Localizable()
+    package init(localizable: Localizable) {
+        self.init(
+            localized: localizable.key,
+            defaultValue: localizable.defaultValue,
+            table: localizable.table,
+            bundle: .from(description: localizable.bundle),
+            locale: localizable.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Localizable {
+    /// This is a comment
+    package static var key: Self {
+        Self (
+            key: "Key",
+            defaultValue: ###"Default Value"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    package static var myDeviceVariant: Self {
+        Self (
+            key: "myDeviceVariant",
+            defaultValue: ###"Multiplatform Original"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    package static func myPlural(_ arg1: Int) -> Self {
+        Self (
+            key: "myPlural",
+            defaultValue: ###"I have \###(arg1) plurals"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    package static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
+        Self (
+            key: "mySubstitute",
+            defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Localizable.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -79,4 +99,66 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.Localizable.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.Localizable.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    package struct Localizable {
+        /// This is a comment
+        package var key: LocalizedStringResource {
+            LocalizedStringResource(localizable: .key)
+        }
+
+        package var myDeviceVariant: LocalizedStringResource {
+            LocalizedStringResource(localizable: .myDeviceVariant)
+        }
+
+        package func myPlural(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(localizable: .myPlural(arg1))
+        }
+
+        package func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
+            LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
+        }
+    }
+
+    private init(localizable: String.Localizable) {
+        self.init(
+            localizable.key,
+            defaultValue: localizable.defaultValue,
+            table: localizable.table,
+            locale: localizable.locale,
+            bundle: .from(description: localizable.bundle)
+        )
+    }
+
+    package static let localizable = Localizable()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     package struct Localizable {
-        package enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the Localizable Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localizable: .key)
+    /// value // "Default Value"
+    /// ```
     package struct Localizable {
         fileprivate enum BundleDescription {
             case main
@@ -131,6 +138,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the Localizable Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .localizable.key)
+    /// value // "Default Value"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.localizable.key)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
     package struct Localizable {
         /// This is a comment
         package var key: LocalizedStringResource {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -1,72 +1,92 @@
 import Foundation
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-extension LocalizedStringResource {
-    /// Constant values for the Localizable Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .localizable.key)
-    /// value // "Default Value"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.localizable.key)
-    /// ```
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String {
     public struct Localizable {
-
-        /// This is a comment
-        public var key: LocalizedStringResource {
-            LocalizedStringResource(
-                "Key",
-                defaultValue: ###"Default Value"###,
-                table: "Localizable",
-                bundle: .current
-            )
+        public enum BundleDescription {
+            case main
+            case atURL(URL)
+            case forClass(AnyClass)
         }
 
-        public var myDeviceVariant: LocalizedStringResource {
-            LocalizedStringResource(
-                "myDeviceVariant",
-                defaultValue: ###"Multiplatform Original"###,
-                table: "Localizable",
-                bundle: .current
-            )
-        }
+        fileprivate let key: StaticString
+        fileprivate let defaultValue: LocalizationValue
+        fileprivate let table: String?
+        fileprivate let locale: Locale
+        fileprivate let bundle: BundleDescription
 
-        public func myPlural(_ arg1: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "myPlural",
-                defaultValue: ###"I have \###(arg1) plurals"###,
-                table: "Localizable",
-                bundle: .current
-            )
-        }
-
-        public func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
-            LocalizedStringResource(
-                "mySubstitute",
-                defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
-                table: "Localizable",
-                bundle: .current
-            )
+        fileprivate init(
+            key: StaticString,
+            defaultValue: LocalizationValue,
+            table: String?,
+            locale: Locale,
+            bundle: BundleDescription
+        ) {
+            self.key = key
+            self.defaultValue = defaultValue
+            self.table = table
+            self.locale = locale
+            self.bundle = bundle
         }
     }
 
-    /// Constant values for the Localizable Strings Catalog
-    ///
-    /// ```swift
-    /// // Accessing the localized value directly
-    /// let value = String(localized: .localizable.key)
-    /// value // "Default Value"
-    ///
-    /// // Working with SwiftUI
-    /// Text(.localizable.key)
-    /// ```
-    public static let localizable = Localizable()
+    public init(localizable: Localizable) {
+        self.init(
+            localized: localizable.key,
+            defaultValue: localizable.defaultValue,
+            table: localizable.table,
+            bundle: .from(description: localizable.bundle),
+            locale: localizable.locale
+        )
+    }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-private extension LocalizedStringResource.BundleDescription {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Localizable {
+    /// This is a comment
+    public static var key: Self {
+        Self (
+            key: "Key",
+            defaultValue: ###"Default Value"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    public static var myDeviceVariant: Self {
+        Self (
+            key: "myDeviceVariant",
+            defaultValue: ###"Multiplatform Original"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    public static func myPlural(_ arg1: Int) -> Self {
+        Self (
+            key: "myPlural",
+            defaultValue: ###"I have \###(arg1) plurals"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+
+    public static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
+        Self (
+            key: "mySubstitute",
+            defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
+            table: "Localizable",
+            locale: .current,
+            bundle: .current
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Localizable.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
     }
@@ -79,4 +99,66 @@ private extension LocalizedStringResource.BundleDescription {
         .forClass(BundleLocator.self)
         #endif
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension Bundle {
+    static func from(description: String.Localizable.BundleDescription) -> Bundle? {
+        switch description {
+        case .main:
+            Bundle.main
+        case .atURL(let url):
+            Bundle(url: url)
+        case .forClass(let anyClass):
+            Bundle(for: anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+private extension LocalizedStringResource.BundleDescription {
+    static func from(description: String.Localizable.BundleDescription) -> Self {
+        switch description {
+        case .main:
+            .main
+        case .atURL(let url):
+            .atURL(url)
+        case .forClass(let anyClass):
+            .forClass(anyClass)
+        }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension LocalizedStringResource {
+    public struct Localizable {
+        /// This is a comment
+        public var key: LocalizedStringResource {
+            LocalizedStringResource(localizable: .key)
+        }
+
+        public var myDeviceVariant: LocalizedStringResource {
+            LocalizedStringResource(localizable: .myDeviceVariant)
+        }
+
+        public func myPlural(_ arg1: Int) -> LocalizedStringResource {
+            LocalizedStringResource(localizable: .myPlural(arg1))
+        }
+
+        public func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
+            LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
+        }
+    }
+
+    private init(localizable: String.Localizable) {
+        self.init(
+            localizable.key,
+            defaultValue: localizable.defaultValue,
+            table: localizable.table,
+            locale: localizable.locale,
+            bundle: .from(description: localizable.bundle)
+        )
+    }
+
+    public static let localizable = Localizable()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -2,6 +2,13 @@ import Foundation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
+    /// Constant values for the Localizable Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localizable: .key)
+    /// value // "Default Value"
+    /// ```
     public struct Localizable {
         fileprivate enum BundleDescription {
             case main
@@ -131,6 +138,18 @@ private extension LocalizedStringResource.BundleDescription {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension LocalizedStringResource {
+    /// Constant values for the Localizable Strings Catalog
+    ///
+    /// ```swift
+    /// // Accessing the localized value directly
+    /// let value = String(localized: .localizable.key)
+    /// value // "Default Value"
+    ///
+    /// // Working with SwiftUI
+    /// Text(.localizable.key)
+    /// ```
+    ///
+    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
     public struct Localizable {
         /// This is a comment
         public var key: LocalizedStringResource {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     public struct Localizable {
-        public enum BundleDescription {
+        fileprivate enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)


### PR DESCRIPTION
- Closes: #30 

Bit of a WIP, but the initial draft that will allow use of xcstrings-tool on iOS 15/macOS 12.

I still need to add documentation back to the generated code, but its mostly there so can be tested out if you need it urgently.

For a strings table called `Localizable` with a key called `foo`, you can use as follows:

```swift
String(localizable: .foo) // iOS 15+ via String.init(localized:defaultValue:table:locale:bundle:)
String(localized: .localizable.foo) // iOS 16+ via LocalizedStringResource
```


