### PR TITLE
Support custom `Locale` when using iOS 15 compatible `String` initialiser

### DIFF
--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -232,6 +232,11 @@ public struct StringGenerator {
                             firstName: variableToken,
                             type: IdentifierTypeSyntax(name: structToken)
                         )
+                        FunctionParameterSyntax(
+                            firstName: "locale",
+                            type: OptionalTypeSyntax(wrappedType: .identifier(.Locale)),
+                            defaultValue: InitializerClauseSyntax(value: NilLiteralExprSyntax())
+                        )
                     }
                 )
             ) {
@@ -241,6 +246,7 @@ public struct StringGenerator {
                         name: .keyword(.`init`)
                     )
                 ) {
+                    // localized: localizable.key
                     LabeledExprSyntax(
                         label: "localized",
                         expression: MemberAccessExprSyntax(
@@ -248,6 +254,7 @@ public struct StringGenerator {
                             name: "key"
                         )
                     )
+                    // defaultValue: localizable.defaultValue
                     LabeledExprSyntax(
                         label: "defaultValue",
                         expression: MemberAccessExprSyntax(
@@ -255,6 +262,7 @@ public struct StringGenerator {
                             name: "defaultValue"
                         )
                     )
+                    // table: localizable.table
                     LabeledExprSyntax(
                         label: "table",
                         expression: MemberAccessExprSyntax(
@@ -262,6 +270,7 @@ public struct StringGenerator {
                             name: "table"
                         )
                     )
+                    // bundle: .from(description: localizable.bundle)
                     LabeledExprSyntax(
                         label: "bundle",
                         expression: FunctionCallExprSyntax(
@@ -280,11 +289,16 @@ public struct StringGenerator {
                             )
                         }
                     )
+                    // locale: locale ?? localizable.locale
                     LabeledExprSyntax(
                         label: "locale",
-                        expression: MemberAccessExprSyntax(
-                            base: DeclReferenceExprSyntax(baseName: variableToken),
-                            name: "locale"
+                        expression: InfixOperatorExprSyntax(
+                            leftOperand: DeclReferenceExprSyntax(baseName: "locale"),
+                            operator: BinaryOperatorExprSyntax(operator: .binaryOperator("??")),
+                            rightOperand: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: variableToken),
+                                name: "locale"
+                            )
                         )
                     )
                 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    internal init(formatSpecifiers: FormatSpecifiers) {
+    internal init(formatSpecifiers: FormatSpecifiers, locale: Locale? = nil) {
         self.init(
             localized: formatSpecifiers.key,
             defaultValue: formatSpecifiers.defaultValue,
             table: formatSpecifiers.table,
             bundle: .from(description: formatSpecifiers.bundle),
-            locale: formatSpecifiers.locale
+            locale: locale ?? formatSpecifiers.locale
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    internal init(localizable: Localizable) {
+    internal init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
             localized: localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
             bundle: .from(description: localizable.bundle),
-            locale: localizable.locale
+            locale: locale ?? localizable.locale
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    internal init(multiline: Multiline) {
+    internal init(multiline: Multiline, locale: Locale? = nil) {
         self.init(
             localized: multiline.key,
             defaultValue: multiline.defaultValue,
             table: multiline.table,
             bundle: .from(description: multiline.bundle),
-            locale: multiline.locale
+            locale: locale ?? multiline.locale
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    internal init(positional: Positional) {
+    internal init(positional: Positional, locale: Locale? = nil) {
         self.init(
             localized: positional.key,
             defaultValue: positional.defaultValue,
             table: positional.table,
             bundle: .from(description: positional.bundle),
-            locale: positional.locale
+            locale: locale ?? positional.locale
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    internal init(simple: Simple) {
+    internal init(simple: Simple, locale: Locale? = nil) {
         self.init(
             localized: simple.key,
             defaultValue: simple.defaultValue,
             table: simple.table,
             bundle: .from(description: simple.bundle),
-            locale: simple.locale
+            locale: locale ?? simple.locale
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    internal init(substitution: Substitution) {
+    internal init(substitution: Substitution, locale: Locale? = nil) {
         self.init(
             localized: substitution.key,
             defaultValue: substitution.defaultValue,
             table: substitution.table,
             bundle: .from(description: substitution.bundle),
-            locale: substitution.locale
+            locale: locale ?? substitution.locale
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    internal init(variations: Variations) {
+    internal init(variations: Variations, locale: Locale? = nil) {
         self.init(
             localized: variations.key,
             defaultValue: variations.defaultValue,
             table: variations.table,
             bundle: .from(description: variations.bundle),
-            locale: variations.locale
+            locale: locale ?? variations.locale
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    package init(localizable: Localizable) {
+    package init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
             localized: localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
             bundle: .from(description: localizable.bundle),
-            locale: localizable.locale
+            locale: locale ?? localizable.locale
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -37,13 +37,13 @@ extension String {
         }
     }
 
-    public init(localizable: Localizable) {
+    public init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
             localized: localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
             bundle: .from(description: localizable.bundle),
-            locale: localizable.locale
+            locale: locale ?? localizable.locale
         )
     }
 }


### PR DESCRIPTION
Unlike `LocalizedStringResource`, the properties within the generated `String.Localizable` type remain private to the generated source and cannot be directly accessed.

This causes an issue if you need to be able to change the `Locale` value to something other than `.current`.

To address this, I've updated `String.init(localizable:)` to be `String.init(localizable:locale:)`, with a nullable value.

If the custom `locale` is `nil` (the default value), we will use the original locale that is supplied by code generation.

If a value is set, it will take priority and allows you to override the language returned, for example:

```swift
String(localizable: .greeting) // Hello
String(localizable: .greeting, locale: Locale(identifier: "fr")) // Bonjour
```