### PR TITLE
Remove support for `CChar`, `UnsafePointer<CChar>` and `UnsafeRawPointer`

### DIFF
--- a/Sources/StringExtractor/ExtractionError.swift
+++ b/Sources/StringExtractor/ExtractionError.swift
@@ -10,6 +10,7 @@ public enum ExtractionError: Error {
     }
 
     case localizationCorrupt(Context)
+    case unsupported(Context)
 }
 
 extension ExtractionError: LocalizedError {
@@ -17,6 +18,8 @@ extension ExtractionError: LocalizedError {
         switch self {
         case .localizationCorrupt(let context):
             "String ‘\(context.key)‘ was corrupt: \(context.debugDescription)"
+        case .unsupported(let context):
+            "String ‘\(context.key)‘ is not supported: \(context.debugDescription)"
         }
     }
 }

--- a/Sources/StringExtractor/PlaceholderType.swift
+++ b/Sources/StringExtractor/PlaceholderType.swift
@@ -25,15 +25,13 @@ enum PlaceholderType {
         }
     }
 
-    var type: String {
+    var type: String? {
         switch self {
         case .object: "String"
         case .float: "Double"
         case .int: "Int"
         case .uint: "UInt"
-        case .char: "CChar"
-        case .cString: "UnsafePointer<CChar>"
-        case .pointer: "UnsafeRawPointer"
+        default: nil
         }
     }
 }

--- a/Sources/StringExtractor/Resource+Extract.swift
+++ b/Sources/StringExtractor/Resource+Extract.swift
@@ -14,7 +14,19 @@ extension Resource {
             switch segment {
             case .string(let contents):
                 defaultValue.append(.string(contents))
-            case .placeholder(let placeholder, let specifiedPosition):
+            case .placeholder(let rawValue, let placeholder, let specifiedPosition):
+                // If the placeholder is an unsupported type, raise an error about the invalid string
+                guard let type = placeholder.type else {
+                    throw ExtractionError.unsupported(
+                        ExtractionError.Context(
+                            key: key,
+                            debugDescription: """
+                            The placeholder format specifier ‘\(rawValue)‘ is not supported.
+                            """
+                        )
+                    )
+                }
+
                 // Figure out the position of the argument for this placeholder
                 let position: Int
                 if let specifiedPosition {
@@ -29,7 +41,7 @@ extension Resource {
                 let argument = Argument(
                     label: labels[position],
                     name: name,
-                    type: placeholder.type
+                    type: type
                 )
 
                 // If the same argument is represented by many placeholders,

--- a/Sources/StringExtractor/StringParser.swift
+++ b/Sources/StringExtractor/StringParser.swift
@@ -5,7 +5,7 @@ import RegexBuilder
 struct StringParser {
     enum ParsedSegment: Equatable {
         case string(contents: String)
-        case placeholder(PlaceholderType, position: Int?)
+        case placeholder(String, PlaceholderType, position: Int?)
     }
 
     /// Parse the given input string including the expansion of the given substitutions
@@ -31,8 +31,12 @@ struct StringParser {
             }
 
             // Now create a segment for the match itself
-            let output: (_, position: Int?, placeholder: PlaceholderType) = match.output
-            segments.append(.placeholder(output.placeholder, position: output.position))
+            let output: (rawValue: Substring, position: Int?, placeholder: PlaceholderType) = match.output
+            segments.append(.placeholder(
+                String(output.rawValue),
+                output.placeholder,
+                position: output.position
+            ))
 
             // Update the last index for the next iteration
             lastIndex = match.range.upperBound

--- a/Tests/XCStringsToolTests/GenerateTests.swift
+++ b/Tests/XCStringsToolTests/GenerateTests.swift
@@ -30,6 +30,14 @@ final class GenerateTests: FixtureTestCase {
             source localization and it's type cannot be inferred.
             """
         )
+
+        // Scenario where format specifiers such as %c are not supported
+        assertError(
+            for: try fixture(named: "!UnsupportedFormatSpecifiers"),
+            localizedDescription: """
+            String ‘Key‘ is not supported: The placeholder format specifier ‘%c‘ is not supported.
+            """
+        )
     }
 
     func testGenerateWithPublicAccessLevel() throws {

--- a/Tests/XCStringsToolTests/__Fixtures__/!UnsupportedFormatSpecifiers.xcstrings
+++ b/Tests/XCStringsToolTests/__Fixtures__/!UnsupportedFormatSpecifiers.xcstrings
@@ -1,0 +1,18 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Key" : {
+      "comment" : "%c is not supported",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test %c"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Tests/XCStringsToolTests/__Fixtures__/FormatSpecifiers.xcstrings
+++ b/Tests/XCStringsToolTests/__Fixtures__/FormatSpecifiers.xcstrings
@@ -13,18 +13,6 @@
         }
       }
     },
-    "c" : {
-      "comment" : "%c should convert to a CChar argument",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Test %c"
-          }
-        }
-      }
-    },
     "d" : {
       "comment" : "%d should convert to an Int argument",
       "extractionState" : "manual",
@@ -93,30 +81,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Test %o"
-          }
-        }
-      }
-    },
-    "p" : {
-      "comment" : "%p should convert to an UnsafeRawPointer argument",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Test %p"
-          }
-        }
-      }
-    },
-    "s" : {
-      "comment" : "%s should convert to an UnsafePointer<CChar> argument",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Test %s"
           }
         }
       }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -61,17 +61,6 @@ extension String.FormatSpecifiers {
         )
     }
 
-    /// %c should convert to a CChar argument
-    internal static func c(_ arg1: CChar) -> Self {
-        Self (
-            key: "c",
-            defaultValue: ###"Test \###(arg1)"###,
-            table: "FormatSpecifiers",
-            locale: .current,
-            bundle: .current
-        )
-    }
-
     /// %d should convert to an Int argument
     internal static func d(_ arg1: Int) -> Self {
         Self (
@@ -131,28 +120,6 @@ extension String.FormatSpecifiers {
     internal static func o(_ arg1: UInt) -> Self {
         Self (
             key: "o",
-            defaultValue: ###"Test \###(arg1)"###,
-            table: "FormatSpecifiers",
-            locale: .current,
-            bundle: .current
-        )
-    }
-
-    /// %p should convert to an UnsafeRawPointer argument
-    internal static func p(_ arg1: UnsafeRawPointer) -> Self {
-        Self (
-            key: "p",
-            defaultValue: ###"Test \###(arg1)"###,
-            table: "FormatSpecifiers",
-            locale: .current,
-            bundle: .current
-        )
-    }
-
-    /// %s should convert to an UnsafePointer<CChar> argument
-    internal static func s(_ arg1: UnsafePointer<CChar>) -> Self {
-        Self (
-            key: "s",
             defaultValue: ###"Test \###(arg1)"###,
             table: "FormatSpecifiers",
             locale: .current,
@@ -247,11 +214,6 @@ extension LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .at(arg1))
         }
 
-        /// %c should convert to a CChar argument
-        internal func c(_ arg1: CChar) -> LocalizedStringResource {
-            LocalizedStringResource(formatSpecifiers: .c(arg1))
-        }
-
         /// %d should convert to an Int argument
         internal func d(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d(arg1))
@@ -280,16 +242,6 @@ extension LocalizedStringResource {
         /// %o should convert to a UInt argument
         internal func o(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .o(arg1))
-        }
-
-        /// %p should convert to an UnsafeRawPointer argument
-        internal func p(_ arg1: UnsafeRawPointer) -> LocalizedStringResource {
-            LocalizedStringResource(formatSpecifiers: .p(arg1))
-        }
-
-        /// %s should convert to an UnsafePointer<CChar> argument
-        internal func s(_ arg1: UnsafePointer<CChar>) -> LocalizedStringResource {
-            LocalizedStringResource(formatSpecifiers: .s(arg1))
         }
 
         /// %u should convert to a UInt argument


### PR DESCRIPTION
Closes #55 

Parsing these types of format specifiers was added to match the behaviour of other tools, but these types are not supported when using `String.LocalizationValue`. Instead, you must format the string and pass it into your localisation as a `%@` argument. 

This change continues to parse these placeholder types instead of skipping them, but will raise a diagnostic error if they are detected. 