### PR TITLE
Prevent Xcode from extracting generated constants as new localizations

### DIFF
--- a/Sources/Documentation/XCStringsToolPlugin.docc/Integrating XCStrings Tool into an Xcode Project Target.md
+++ b/Sources/Documentation/XCStringsToolPlugin.docc/Integrating XCStrings Tool into an Xcode Project Target.md
@@ -32,16 +32,6 @@ Expand the **Run Build Tool Plug-ins** group and click the **+** button. In the 
 
 ![A screenshot of the Build Phases screen after adding the XCStringsToolPlugin](Xcode-AddedBuildToolPlugin)
 
-### Configuring Build Settings
-
-Because XCStrings Tool helps you to make your Strings Catalog the source of truth for your localizations, there are some build settings that you want to ensure are correctly set for your target:
-
-- Localization Prefers String Catalogs (`LOCALIZATION_PREFERS_STRING_CATALOGS`): `YES`
-- Localized String SwiftUI Support (`LOCALIZED_STRING_SWIFTUI_SUPPORT`): `NO`
-- Use Compiler to Extract Swift Strings (`SWIFT_EMIT_LOC_STRINGS`): `NO`
-
-For the last two build settings, you want to ensure that these are set to `NO` so that building your project will not cause localized strings to be automatically populated in your Strings Catalog. Automatically managed strings will produce build warning because XCStrings Tool will skip them when producing constant definitions.
-
 ### Review your Strings Catalog
 
 Before building the product, let's just review our Strings Catalog quickly:

--- a/Sources/StringExtractor/Resource+Extract.swift
+++ b/Sources/StringExtractor/Resource+Extract.swift
@@ -43,19 +43,19 @@ extension Resource {
                 let argument = Argument(
                     label: labels[position],
                     name: name,
-                    type: type.identifier
+                    placeholderType: type
                 )
 
                 // If the same argument is represented by many placeholders,
                 // ensure that they use the same type
-                if let existing = arguments[position], existing.type != argument.type {
+                if let existing = arguments[position], existing.placeholderType != argument.placeholderType {
                     throw ExtractionError.localizationCorrupt(
                         ExtractionError.Context(
                             key: key,
                             debugDescription: """
                             The argument at position \(position) was specified multiple \
-                            times but with different data types. First ‘\(existing.type)‘, \
-                            then ‘\(argument.type)‘.
+                            times but with different data types. First ‘\(existing.placeholderType)‘, \
+                            then ‘\(argument.placeholderType)‘.
                             """
                         )
                     )
@@ -99,17 +99,6 @@ private extension String.LocalizationValue.Placeholder {
             self = .uint
         default:
             return nil
-        }
-    }
-
-    var identifier: String {
-        switch self {
-        case .int: "Int"
-        case .uint: "UInt"
-        case .float: "Float"
-        case .double: "Double"
-        case .object: "String"
-        @unknown default: "AnyObject"
         }
     }
 }

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -504,18 +504,37 @@ public struct StringGenerator {
                                 }
                             )
 
-                            // return String.LocalizationValue(stringInterpolation: interpolation)
+                            // let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+                            VariableDeclSyntax(bindingSpecifier: .keyword(.let)) {
+                                PatternBindingSyntax(
+                                    pattern: IdentifierPatternSyntax(identifier: "makeDefaultValue"),
+                                    initializer: InitializerClauseSyntax(
+                                        value: MemberAccessExprSyntax(
+                                            base: MemberAccessExprSyntax(
+                                                base: DeclReferenceExprSyntax(baseName: .type(.String)),
+                                                declName: DeclReferenceExprSyntax(baseName: .type(.LocalizationValue))
+                                            ),
+                                            declName: DeclReferenceExprSyntax(
+                                                baseName: .keyword(.`init`),
+                                                argumentNames: DeclNameArgumentsSyntax(
+                                                    arguments: DeclNameArgumentListSyntax {
+                                                        DeclNameArgumentSyntax(name: "stringInterpolation")
+                                                    }
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            }
+
+                            // return makeDefaultValue(stringInterpolation)
                             ReturnStmtSyntax(
                                 expression: FunctionCallExprSyntax(
-                                    callee: MemberAccessExprSyntax(
-                                        base: DeclReferenceExprSyntax(baseName: .type(.String)),
-                                        name: .type(.LocalizationValue)
-                                    )
+                                    callee: DeclReferenceExprSyntax(baseName: "makeDefaultValue")
                                 ) {
-                                    // stringInterpolation: stringInterpolation
                                     LabeledExprSyntax(
-                                        label: "stringInterpolation",
-                                        expression: DeclReferenceExprSyntax(baseName: "stringInterpolation"))
+                                        expression: DeclReferenceExprSyntax(baseName: "stringInterpolation")
+                                    )
                                 }
                             )
                         })

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -36,6 +36,7 @@ public struct StringGenerator {
             generateImports()
             generateStringExtension()
             generateStringsTableExtension()
+            generateStringsTableDefaultValueExtension()
             generateBundleDescriptionExtension()
             generateBundleExtension()
             generateFoundationBundleDescriptionExtension()
@@ -56,7 +57,6 @@ public struct StringGenerator {
 
     func generateStringExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            availability: .wwdc2021,
             extendedType: .identifier(.String)
         ) {
             // Table struct
@@ -97,9 +97,75 @@ public struct StringGenerator {
                                 )
                             )
                         }
-                    },
-                    trailingTrivia: .newlines(2)
+                    }
                 )
+                .with(\.trailingTrivia, .newlines(2))
+
+                // Argument
+                EnumDeclSyntax(
+                    modifiers: [
+                        DeclModifierSyntax(name: .keyword(.fileprivate))
+                    ],
+                    name: .type(.Argument),
+                    memberBlockBuilder: {
+                        // case object(String)
+                        EnumCaseDeclSyntax {
+                            EnumCaseElementSyntax(
+                                name: .identifier("object"),
+                                parameterClause: EnumCaseParameterClauseSyntax(
+                                    parameters: [
+                                        "String"
+                                    ]
+                                )
+                            )
+                        }
+                        // case int(Int)
+                        EnumCaseDeclSyntax {
+                            EnumCaseElementSyntax(
+                                name: .identifier("int"),
+                                parameterClause: EnumCaseParameterClauseSyntax(
+                                    parameters: [
+                                        "Int"
+                                    ]
+                                )
+                            )
+                        }
+                        // case uint(UInt)
+                        EnumCaseDeclSyntax {
+                            EnumCaseElementSyntax(
+                                name: .identifier("uint"),
+                                parameterClause: EnumCaseParameterClauseSyntax(
+                                    parameters: [
+                                        "UInt"
+                                    ]
+                                )
+                            )
+                        }
+                        // case double(Double)
+                        EnumCaseDeclSyntax {
+                            EnumCaseElementSyntax(
+                                name: .identifier("double"),
+                                parameterClause: EnumCaseParameterClauseSyntax(
+                                    parameters: [
+                                        "Double"
+                                    ]
+                                )
+                            )
+                        }
+                        // case float(Float)
+                        EnumCaseDeclSyntax {
+                            EnumCaseElementSyntax(
+                                name: .identifier("float"),
+                                parameterClause: EnumCaseParameterClauseSyntax(
+                                    parameters: [
+                                        "Float"
+                                    ]
+                                )
+                            )
+                        }
+                    }
+                )
+                .with(\.trailingTrivia, .newlines(2))
 
                 // Properties
                 VariableDeclSyntax(
@@ -117,8 +183,10 @@ public struct StringGenerator {
                         DeclModifierSyntax(name: .keyword(.fileprivate)),
                     ],
                     .let,
-                    name: PatternSyntax(IdentifierPatternSyntax(identifier: "defaultValue")),
-                    type: TypeAnnotationSyntax(type: .identifier(.LocalizationValue))
+                    name: PatternSyntax(IdentifierPatternSyntax(identifier: "arguments")),
+                    type: TypeAnnotationSyntax(
+                        type: ArrayTypeSyntax(element: .identifier(.Argument))
+                    )
                 )
                 VariableDeclSyntax(
                     modifiers: [
@@ -159,8 +227,8 @@ public struct StringGenerator {
                                 type: .identifier(.StaticString)
                             )
                             FunctionParameterSyntax(
-                                firstName: "defaultValue",
-                                type: .identifier(.LocalizationValue)
+                                firstName: "arguments",
+                                type: ArrayTypeSyntax(element: .identifier(.Argument))
                             )
                             FunctionParameterSyntax(
                                 firstName: "table",
@@ -189,10 +257,10 @@ public struct StringGenerator {
                     InfixOperatorExprSyntax(
                         leftOperand: MemberAccessExprSyntax(
                             base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
-                            name: "defaultValue"
+                            name: "arguments"
                         ),
                         operator: AssignmentExprSyntax(),
-                        rightOperand: DeclReferenceExprSyntax(baseName: "defaultValue")
+                        rightOperand: DeclReferenceExprSyntax(baseName: "arguments")
                     )
                     InfixOperatorExprSyntax(
                         leftOperand: MemberAccessExprSyntax(
@@ -223,6 +291,12 @@ public struct StringGenerator {
 
             // String initialiser
             InitializerDeclSyntax(
+                attributes: [
+                    .attribute(
+                        AttributeSyntax(availability: .wwdc2021)
+                            .with(\.trailingTrivia, .newline)
+                    )
+                ],
                 modifiers: [
                     DeclModifierSyntax(name: accessLevel.token),
                 ],
@@ -310,7 +384,6 @@ public struct StringGenerator {
 
     func generateStringsTableExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            availability: .wwdc2021,
             extendedType: localTableMemberType
         ) {
             for resource in resources {
@@ -319,6 +392,134 @@ public struct StringGenerator {
                     variableToken: variableToken,
                     accessLevel: accessLevel.token,
                     isLocalizedStringResource: false
+                )
+            }
+        }
+        .spacingMembers()
+    }
+
+    func generateStringsTableDefaultValueExtension() -> ExtensionDeclSyntax {
+        ExtensionDeclSyntax(
+            availability: .wwdc2021,
+            extendedType: localTableMemberType
+        ) {
+            // var defaultValue: String.LocalizationValue { ... }
+            VariableDeclSyntax(bindingSpecifier: .keyword(.var)) {
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier("defaultValue")),
+                    typeAnnotation: TypeAnnotationSyntax(
+                        type: MemberTypeSyntax(
+                            baseType: .identifier(.String),
+                            name: .type(.LocalizationValue)
+                        )
+                    ),
+                    accessorBlock: AccessorBlockSyntax(
+                        accessors: .getter(CodeBlockItemListSyntax {
+                            // var interpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+                            VariableDeclSyntax(bindingSpecifier: .keyword(.var)) {
+                                PatternBindingSyntax(
+                                    pattern: IdentifierPatternSyntax(identifier: .identifier("stringInterpolation")),
+                                    initializer: InitializerClauseSyntax(
+                                        value: FunctionCallExprSyntax(
+                                            callee: MemberAccessExprSyntax(
+                                                base: MemberAccessExprSyntax(
+                                                    base: DeclReferenceExprSyntax(baseName: .type(.String)),
+                                                    declName: DeclReferenceExprSyntax(baseName: .type(.LocalizationValue))
+                                                ),
+                                                declName: DeclReferenceExprSyntax(baseName: .type(.StringInterpolation))
+                                            )
+                                        ) {
+                                            // literalCapacity: 0
+                                            LabeledExprSyntax(
+                                                label: "literalCapacity",
+                                                expression: IntegerLiteralExprSyntax(0)
+                                            )
+                                            // interpolationCount: arguments.count
+                                            LabeledExprSyntax(
+                                                label: "interpolationCount",
+                                                expression: MemberAccessExprSyntax(
+                                                    base: DeclReferenceExprSyntax(baseName: "arguments"),
+                                                    declName: DeclReferenceExprSyntax(baseName: "count")
+                                                )
+                                            )
+                                        }
+                                    )
+                                )
+                            }
+
+                            // for argument in arguments { ... }
+                            ForStmtSyntax(
+                                pattern: IdentifierPatternSyntax(identifier: "argument"),
+                                sequence: DeclReferenceExprSyntax(baseName: "arguments"),
+                                body: CodeBlockSyntax {
+                                    // switch argument { ... }
+                                    SwitchExprSyntax(subject: DeclReferenceExprSyntax(baseName: "argument")) {
+                                        // case object(let object):
+                                        //     stringInterpolation.appendInterpolation(string)
+                                        for placeholder in String.LocalizationValue.Placeholder.allCases {
+                                            SwitchCaseSyntax(
+                                                // case object(let value):
+                                                label: .case(
+                                                    SwitchCaseLabelSyntax(
+                                                        caseItems: SwitchCaseItemListSyntax {
+                                                            SwitchCaseItemSyntax(
+                                                                pattern: ExpressionPatternSyntax(
+                                                                    expression: FunctionCallExprSyntax(
+                                                                        callee: MemberAccessExprSyntax(
+                                                                            declName: DeclReferenceExprSyntax(baseName: placeholder.caseName)
+                                                                        )
+                                                                    ) {
+                                                                        LabeledExprSyntax(
+                                                                            expression: PatternExprSyntax(
+                                                                                pattern: ValueBindingPatternSyntax(
+                                                                                    bindingSpecifier: .keyword(.let),
+                                                                                    pattern: IdentifierPatternSyntax(
+                                                                                        identifier: "value"
+                                                                                    )
+                                                                                )
+                                                                            )
+                                                                        )
+                                                                    }
+                                                                )
+                                                            )
+                                                        }
+                                                    )
+                                                ),
+                                                // stringInterpolation.appendInterpolation(value)
+                                                statements: CodeBlockItemListSyntax {
+                                                    FunctionCallExprSyntax(
+                                                        callee: MemberAccessExprSyntax(
+                                                            base: DeclReferenceExprSyntax(baseName: "stringInterpolation"),
+                                                            name: "appendInterpolation"
+                                                        )
+                                                    ) {
+                                                        LabeledExprSyntax(
+                                                            expression: DeclReferenceExprSyntax(baseName: "value")
+                                                        )
+                                                    }
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            )
+
+                            // return String.LocalizationValue(stringInterpolation: interpolation)
+                            ReturnStmtSyntax(
+                                expression: FunctionCallExprSyntax(
+                                    callee: MemberAccessExprSyntax(
+                                        base: DeclReferenceExprSyntax(baseName: .type(.String)),
+                                        name: .type(.LocalizationValue)
+                                    )
+                                ) {
+                                    // stringInterpolation: stringInterpolation
+                                    LabeledExprSyntax(
+                                        label: "stringInterpolation",
+                                        expression: DeclReferenceExprSyntax(baseName: "stringInterpolation"))
+                                }
+                            )
+                        })
+                    )
                 )
             }
         }
@@ -986,7 +1187,7 @@ extension Resource {
                 ) {
                     LabeledExprSyntax(label: "key", expression: keyExpr)
 
-                    LabeledExprSyntax(label: "defaultValue", expression: defaultValueExpr)
+                    LabeledExprSyntax(label: "arguments", expression: argumentsExpr)
 
                     LabeledExprSyntax(
                         label: "table",
@@ -1042,17 +1243,24 @@ extension Resource {
         StringLiteralExprSyntax(content: key)
     }
 
-    // TODO: Improve this
-    // 1. Maybe use multiline string literals?
-    // 2. Calculate the correct number of pounds to be used.
-    var defaultValueExpr: StringLiteralExprSyntax {
-        StringLiteralExprSyntax(
-            openingPounds: .rawStringPoundDelimiter("###"),
-            openingQuote: .stringQuoteToken(),
-            segments: StringLiteralSegmentListSyntax(defaultValue.map(\.element)),
-            closingQuote: .stringQuoteToken(),
-            closingPounds: .rawStringPoundDelimiter("###")
-        )
+    var argumentsExpr: ArrayExprSyntax {
+        ArrayExprSyntax {
+            for argument in self.arguments {
+                // .object(arg1)
+                ArrayElementSyntax(
+                    expression: FunctionCallExprSyntax(
+                        callee: MemberAccessExprSyntax(name: argument.placeholderType.caseName)
+                    ) {
+                        LabeledExprSyntax(
+                            expression: DeclReferenceExprSyntax(
+                                baseName: .identifier(argument.name)
+                            )
+                        )
+                    }
+                )
+            }
+        }
+        .multiline()
     }
 }
 
@@ -1061,7 +1269,7 @@ extension Argument {
         FunctionParameterSyntax(
             firstName: label.flatMap { .identifier($0) } ?? .wildcardToken(),
             secondName: .identifier(name),
-            type: IdentifierTypeSyntax(name: .identifier(type))
+            type: IdentifierTypeSyntax(name: .identifier(placeholderType.identifier))
         )
     }
 }
@@ -1164,4 +1372,36 @@ extension Trivia {
             .map { [.docLineComment($0.trimmingCharacters(in: .whitespaces)), .newlines(1)] }
             .reduce([], +)
     }
+}
+
+private extension String.LocalizationValue.Placeholder {
+    var identifier: String {
+        switch self {
+        case .int: "Int"
+        case .uint: "UInt"
+        case .float: "Float"
+        case .double: "Double"
+        case .object: "String"
+        @unknown default: "AnyObject"
+        }
+    }
+
+    var caseName: TokenSyntax {
+        switch self {
+        case .int: "int"
+        case .uint: "uint"
+        case .float: "float"
+        case .double: "double"
+        case .object: "object"
+        @unknown default: .identifier(String(describing: self))
+        }
+    }
+
+    static let allCases: [Self] = [
+        .int,
+        .uint,
+        .float,
+        .double,
+        .object
+    ]
 }

--- a/Sources/StringGenerator/SwiftSyntax/ArrayExprSyntax.swift
+++ b/Sources/StringGenerator/SwiftSyntax/ArrayExprSyntax.swift
@@ -1,0 +1,18 @@
+import SwiftSyntax
+
+extension ArrayExprSyntax {
+    func multiline() -> ArrayExprSyntax {
+        if elements.isEmpty {
+            self
+        } else {
+            updating(\.elements) { elements in
+                elements = ArrayElementListSyntax {
+                    for element in elements {
+                        element.with(\.leadingTrivia, .newline)
+                    }
+                }
+            }
+            .with(\.rightSquare, .rightSquareToken(leadingTrivia: .newline))
+        }
+    }
+}

--- a/Sources/StringGenerator/SwiftSyntax/ExtensionDeclSyntax.swift
+++ b/Sources/StringGenerator/SwiftSyntax/ExtensionDeclSyntax.swift
@@ -3,18 +3,22 @@ import SwiftSyntaxBuilder
 
 extension ExtensionDeclSyntax {
     init(
-        availability: AvailabilityArgumentListSyntax,
+        availability: AvailabilityArgumentListSyntax? = nil,
         accessLevel: Keyword? = nil,
         extendedType: some TypeSyntaxProtocol,
         @MemberBlockItemListBuilder memberBlockBuilder: () -> MemberBlockItemListSyntax
     ) {
-        self.init(
-            attributes: [
+        let attributes = AttributeListSyntax {
+            if let availability {
                 .attribute(
                     AttributeSyntax(availability: availability)
                         .with(\.trailingTrivia, .newline)
                 )
-            ],
+            }
+        }
+
+        self.init(
+            attributes: attributes,
             modifiers: DeclModifierListSyntax {
                 if let accessLevel {
                     DeclModifierSyntax(name: .keyword(accessLevel))

--- a/Sources/StringGenerator/SwiftSyntax/TokenSyntax+Types.swift
+++ b/Sources/StringGenerator/SwiftSyntax/TokenSyntax+Types.swift
@@ -5,11 +5,13 @@ extension TokenSyntax {
         case String
         case StaticString
         case LocalizationValue
+        case StringInterpolation
         case Locale
         case Bundle
         case AnyClass
         case BundleDescription
         case LocalizedStringResource
+        case Argument
     }
 
     static func type(_ value: MetaType) -> TokenSyntax {

--- a/Sources/StringResource/Argument.swift
+++ b/Sources/StringResource/Argument.swift
@@ -8,11 +8,11 @@ public struct Argument: Equatable {
     public let name: String
 
     /// The type of the argument
-    public let type: String
+    public let placeholderType: String.LocalizationValue.Placeholder
 
-    public init(label: String?, name: String, type: String) {
+    public init(label: String?, name: String, placeholderType: String.LocalizationValue.Placeholder) {
         self.label = label
         self.name = name
-        self.type = type
+        self.placeholderType = placeholderType
     }
 }

--- a/Tests/XCStringsToolTests/GenerateTests.swift
+++ b/Tests/XCStringsToolTests/GenerateTests.swift
@@ -18,7 +18,7 @@ final class GenerateTests: FixtureTestCase {
             for: try fixture(named: "!MismatchingArgumentType"),
             localizedDescription: """
             String ‘Key‘ was corrupt: The argument at position 1 was specified multiple \
-            times but with different data types. First ‘Int‘, then ‘String‘.
+            times but with different data types. First ‘int‘, then ‘object‘.
             """
         )
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -237,7 +237,8 @@ extension String.FormatSpecifiers {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     /// Constant values for the FormatSpecifiers Strings Catalog
     ///
@@ -16,27 +15,36 @@ extension String {
             case forClass(AnyClass)
         }
 
+        fileprivate enum Argument {
+            case object(String)
+            case int(Int)
+            case uint(UInt)
+            case double(Double)
+            case float(Float)
+        }
+
         fileprivate let key: StaticString
-        fileprivate let defaultValue: LocalizationValue
+        fileprivate let arguments: [Argument]
         fileprivate let table: String?
         fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
-            defaultValue: LocalizationValue,
+            arguments: [Argument],
             table: String?,
             locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
-            self.defaultValue = defaultValue
+            self.arguments = arguments
             self.table = table
             self.locale = locale
             self.bundle = bundle
         }
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(formatSpecifiers: FormatSpecifiers, locale: Locale? = nil) {
         self.init(
             localized: formatSpecifiers.key,
@@ -48,13 +56,14 @@ extension String {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String.FormatSpecifiers {
     /// %@ should convert to a String argument
     internal static func at(_ arg1: String) -> Self {
         Self (
             key: "at",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .object(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -65,7 +74,9 @@ extension String.FormatSpecifiers {
     internal static func d(_ arg1: Int) -> Self {
         Self (
             key: "d",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .int(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -76,7 +87,9 @@ extension String.FormatSpecifiers {
     internal static func d_length(_ arg1: Int) -> Self {
         Self (
             key: "d_length",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .int(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -87,7 +100,9 @@ extension String.FormatSpecifiers {
     internal static func f(_ arg1: Double) -> Self {
         Self (
             key: "f",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .double(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -98,7 +113,9 @@ extension String.FormatSpecifiers {
     internal static func f_precision(_ arg1: Double) -> Self {
         Self (
             key: "f_precision",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .double(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -109,7 +126,9 @@ extension String.FormatSpecifiers {
     internal static func i(_ arg1: Int) -> Self {
         Self (
             key: "i",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .int(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -120,7 +139,9 @@ extension String.FormatSpecifiers {
     internal static func o(_ arg1: UInt) -> Self {
         Self (
             key: "o",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .uint(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -131,7 +152,7 @@ extension String.FormatSpecifiers {
     internal static var percentage: Self {
         Self (
             key: "percentage",
-            defaultValue: ###"Test %"###,
+            arguments: [],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -142,7 +163,7 @@ extension String.FormatSpecifiers {
     internal static var percentage_escaped: Self {
         Self (
             key: "percentage_escaped",
-            defaultValue: ###"Test %%"###,
+            arguments: [],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -153,7 +174,7 @@ extension String.FormatSpecifiers {
     internal static var percentage_escaped_space_o: Self {
         Self (
             key: "percentage_escaped_space_o",
-            defaultValue: ###"Test 50%% off"###,
+            arguments: [],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -164,7 +185,7 @@ extension String.FormatSpecifiers {
     internal static var percentage_space_o: Self {
         Self (
             key: "percentage_space_o",
-            defaultValue: ###"Test 50% off"###,
+            arguments: [],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -175,7 +196,9 @@ extension String.FormatSpecifiers {
     internal static func u(_ arg1: UInt) -> Self {
         Self (
             key: "u",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .uint(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
@@ -186,11 +209,35 @@ extension String.FormatSpecifiers {
     internal static func x(_ arg1: UInt) -> Self {
         Self (
             key: "x",
-            defaultValue: ###"Test \###(arg1)"###,
+            arguments: [
+                .uint(arg1)
+            ],
             table: "FormatSpecifiers",
             locale: .current,
             bundle: .current
         )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.FormatSpecifiers {
+    var defaultValue: String.LocalizationValue {
+        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+        for argument in arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        return String.LocalizationValue(stringInterpolation: stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     /// Constant values for the Localizable Strings Catalog
     ///
@@ -16,27 +15,36 @@ extension String {
             case forClass(AnyClass)
         }
 
+        fileprivate enum Argument {
+            case object(String)
+            case int(Int)
+            case uint(UInt)
+            case double(Double)
+            case float(Float)
+        }
+
         fileprivate let key: StaticString
-        fileprivate let defaultValue: LocalizationValue
+        fileprivate let arguments: [Argument]
         fileprivate let table: String?
         fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
-            defaultValue: LocalizationValue,
+            arguments: [Argument],
             table: String?,
             locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
-            self.defaultValue = defaultValue
+            self.arguments = arguments
             self.table = table
             self.locale = locale
             self.bundle = bundle
         }
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
             localized: localizable.key,
@@ -48,13 +56,12 @@ extension String {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String.Localizable {
     /// This is a comment
     internal static var key: Self {
         Self (
             key: "Key",
-            defaultValue: ###"Default Value"###,
+            arguments: [],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -64,7 +71,7 @@ extension String.Localizable {
     internal static var myDeviceVariant: Self {
         Self (
             key: "myDeviceVariant",
-            defaultValue: ###"Multiplatform Original"###,
+            arguments: [],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -74,7 +81,9 @@ extension String.Localizable {
     internal static func myPlural(_ arg1: Int) -> Self {
         Self (
             key: "myPlural",
-            defaultValue: ###"I have \###(arg1) plurals"###,
+            arguments: [
+                .int(arg1)
+            ],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -84,11 +93,36 @@ extension String.Localizable {
     internal static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
         Self (
             key: "mySubstitute",
-            defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
+            arguments: [
+                .int(arg1),
+                .int(arg2)
+            ],
             table: "Localizable",
             locale: .current,
             bundle: .current
         )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Localizable {
+    var defaultValue: String.LocalizationValue {
+        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+        for argument in arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        return String.LocalizationValue(stringInterpolation: stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -122,7 +122,8 @@ extension String.Localizable {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -89,7 +89,8 @@ extension String.Multiline {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     /// Constant values for the Multiline Strings Catalog
     ///
@@ -16,27 +15,36 @@ extension String {
             case forClass(AnyClass)
         }
 
+        fileprivate enum Argument {
+            case object(String)
+            case int(Int)
+            case uint(UInt)
+            case double(Double)
+            case float(Float)
+        }
+
         fileprivate let key: StaticString
-        fileprivate let defaultValue: LocalizationValue
+        fileprivate let arguments: [Argument]
         fileprivate let table: String?
         fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
-            defaultValue: LocalizationValue,
+            arguments: [Argument],
             table: String?,
             locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
-            self.defaultValue = defaultValue
+            self.arguments = arguments
             self.table = table
             self.locale = locale
             self.bundle = bundle
         }
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(multiline: Multiline, locale: Locale? = nil) {
         self.init(
             localized: multiline.key,
@@ -48,7 +56,6 @@ extension String {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String.Multiline {
     /// This example tests the following:
     /// 1. That line breaks in the defaultValue are supported
@@ -56,11 +63,33 @@ extension String.Multiline {
     internal static var multiline: Self {
         Self (
             key: "multiline",
-            defaultValue: ###"Options:\###n- One\###n- Two\###n- Three"###,
+            arguments: [],
             table: "Multiline",
             locale: .current,
             bundle: .current
         )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Multiline {
+    var defaultValue: String.LocalizationValue {
+        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+        for argument in arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        return String.LocalizationValue(stringInterpolation: stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -116,7 +116,8 @@ extension String.Positional {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -87,7 +87,8 @@ extension String.Simple {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     /// Constant values for the Simple Strings Catalog
     ///
@@ -16,27 +15,36 @@ extension String {
             case forClass(AnyClass)
         }
 
+        fileprivate enum Argument {
+            case object(String)
+            case int(Int)
+            case uint(UInt)
+            case double(Double)
+            case float(Float)
+        }
+
         fileprivate let key: StaticString
-        fileprivate let defaultValue: LocalizationValue
+        fileprivate let arguments: [Argument]
         fileprivate let table: String?
         fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
-            defaultValue: LocalizationValue,
+            arguments: [Argument],
             table: String?,
             locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
-            self.defaultValue = defaultValue
+            self.arguments = arguments
             self.table = table
             self.locale = locale
             self.bundle = bundle
         }
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(simple: Simple, locale: Locale? = nil) {
         self.init(
             localized: simple.key,
@@ -48,17 +56,38 @@ extension String {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String.Simple {
     /// This is a simple key and value
     internal static var simpleKey: Self {
         Self (
             key: "SimpleKey",
-            defaultValue: ###"My Value"###,
+            arguments: [],
             table: "Simple",
             locale: .current,
             bundle: .current
         )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Simple {
+    var defaultValue: String.LocalizationValue {
+        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+        for argument in arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        return String.LocalizationValue(stringInterpolation: stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -91,7 +91,8 @@ extension String.Substitution {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     /// Constant values for the Substitution Strings Catalog
     ///
@@ -16,27 +15,36 @@ extension String {
             case forClass(AnyClass)
         }
 
+        fileprivate enum Argument {
+            case object(String)
+            case int(Int)
+            case uint(UInt)
+            case double(Double)
+            case float(Float)
+        }
+
         fileprivate let key: StaticString
-        fileprivate let defaultValue: LocalizationValue
+        fileprivate let arguments: [Argument]
         fileprivate let table: String?
         fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
-            defaultValue: LocalizationValue,
+            arguments: [Argument],
             table: String?,
             locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
-            self.defaultValue = defaultValue
+            self.arguments = arguments
             self.table = table
             self.locale = locale
             self.bundle = bundle
         }
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(substitution: Substitution, locale: Locale? = nil) {
         self.init(
             localized: substitution.key,
@@ -48,17 +56,42 @@ extension String {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String.Substitution {
     /// A string that uses substitutions as well as arguments
     internal static func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> Self {
         Self (
             key: "substitutions_example.string",
-            defaultValue: ###"\###(arg1)! There are \###(arg2) strings and you have \###(arg3) remaining"###,
+            arguments: [
+                .object(arg1),
+                .int(arg2),
+                .int(arg3)
+            ],
             table: "Substitution",
             locale: .current,
             bundle: .current
         )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Substitution {
+    var defaultValue: String.LocalizationValue {
+        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+        for argument in arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        return String.LocalizationValue(stringInterpolation: stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     /// Constant values for the Variations Strings Catalog
     ///
@@ -16,27 +15,36 @@ extension String {
             case forClass(AnyClass)
         }
 
+        fileprivate enum Argument {
+            case object(String)
+            case int(Int)
+            case uint(UInt)
+            case double(Double)
+            case float(Float)
+        }
+
         fileprivate let key: StaticString
-        fileprivate let defaultValue: LocalizationValue
+        fileprivate let arguments: [Argument]
         fileprivate let table: String?
         fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
-            defaultValue: LocalizationValue,
+            arguments: [Argument],
             table: String?,
             locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
-            self.defaultValue = defaultValue
+            self.arguments = arguments
             self.table = table
             self.locale = locale
             self.bundle = bundle
         }
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(variations: Variations, locale: Locale? = nil) {
         self.init(
             localized: variations.key,
@@ -48,13 +56,12 @@ extension String {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String.Variations {
     /// A string that should have a macOS variation to replace 'Tap' with 'Click'
     internal static var stringDevice: Self {
         Self (
             key: "String.Device",
-            defaultValue: ###"Tap to open"###,
+            arguments: [],
             table: "Variations",
             locale: .current,
             bundle: .current
@@ -64,11 +71,35 @@ extension String.Variations {
     internal static func stringPlural(_ arg1: Int) -> Self {
         Self (
             key: "String.Plural",
-            defaultValue: ###"I have \###(arg1) strings"###,
+            arguments: [
+                .int(arg1)
+            ],
             table: "Variations",
             locale: .current,
             bundle: .current
         )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Variations {
+    var defaultValue: String.LocalizationValue {
+        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+        for argument in arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        return String.LocalizationValue(stringInterpolation: stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -99,7 +99,8 @@ extension String.Variations {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -122,7 +122,8 @@ extension String.Localizable {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     /// Constant values for the Localizable Strings Catalog
     ///
@@ -16,27 +15,36 @@ extension String {
             case forClass(AnyClass)
         }
 
+        fileprivate enum Argument {
+            case object(String)
+            case int(Int)
+            case uint(UInt)
+            case double(Double)
+            case float(Float)
+        }
+
         fileprivate let key: StaticString
-        fileprivate let defaultValue: LocalizationValue
+        fileprivate let arguments: [Argument]
         fileprivate let table: String?
         fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
-            defaultValue: LocalizationValue,
+            arguments: [Argument],
             table: String?,
             locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
-            self.defaultValue = defaultValue
+            self.arguments = arguments
             self.table = table
             self.locale = locale
             self.bundle = bundle
         }
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     package init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
             localized: localizable.key,
@@ -48,13 +56,12 @@ extension String {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String.Localizable {
     /// This is a comment
     package static var key: Self {
         Self (
             key: "Key",
-            defaultValue: ###"Default Value"###,
+            arguments: [],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -64,7 +71,7 @@ extension String.Localizable {
     package static var myDeviceVariant: Self {
         Self (
             key: "myDeviceVariant",
-            defaultValue: ###"Multiplatform Original"###,
+            arguments: [],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -74,7 +81,9 @@ extension String.Localizable {
     package static func myPlural(_ arg1: Int) -> Self {
         Self (
             key: "myPlural",
-            defaultValue: ###"I have \###(arg1) plurals"###,
+            arguments: [
+                .int(arg1)
+            ],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -84,11 +93,36 @@ extension String.Localizable {
     package static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
         Self (
             key: "mySubstitute",
-            defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
+            arguments: [
+                .int(arg1),
+                .int(arg2)
+            ],
             table: "Localizable",
             locale: .current,
             bundle: .current
         )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Localizable {
+    var defaultValue: String.LocalizationValue {
+        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+        for argument in arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        return String.LocalizationValue(stringInterpolation: stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String {
     /// Constant values for the Localizable Strings Catalog
     ///
@@ -16,27 +15,36 @@ extension String {
             case forClass(AnyClass)
         }
 
+        fileprivate enum Argument {
+            case object(String)
+            case int(Int)
+            case uint(UInt)
+            case double(Double)
+            case float(Float)
+        }
+
         fileprivate let key: StaticString
-        fileprivate let defaultValue: LocalizationValue
+        fileprivate let arguments: [Argument]
         fileprivate let table: String?
         fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
-            defaultValue: LocalizationValue,
+            arguments: [Argument],
             table: String?,
             locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
-            self.defaultValue = defaultValue
+            self.arguments = arguments
             self.table = table
             self.locale = locale
             self.bundle = bundle
         }
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
             localized: localizable.key,
@@ -48,13 +56,12 @@ extension String {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension String.Localizable {
     /// This is a comment
     public static var key: Self {
         Self (
             key: "Key",
-            defaultValue: ###"Default Value"###,
+            arguments: [],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -64,7 +71,7 @@ extension String.Localizable {
     public static var myDeviceVariant: Self {
         Self (
             key: "myDeviceVariant",
-            defaultValue: ###"Multiplatform Original"###,
+            arguments: [],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -74,7 +81,9 @@ extension String.Localizable {
     public static func myPlural(_ arg1: Int) -> Self {
         Self (
             key: "myPlural",
-            defaultValue: ###"I have \###(arg1) plurals"###,
+            arguments: [
+                .int(arg1)
+            ],
             table: "Localizable",
             locale: .current,
             bundle: .current
@@ -84,11 +93,36 @@ extension String.Localizable {
     public static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
         Self (
             key: "mySubstitute",
-            defaultValue: ###"\###(arg1): People liked \###(arg2) posts"###,
+            arguments: [
+                .int(arg1),
+                .int(arg2)
+            ],
             table: "Localizable",
             locale: .current,
             bundle: .current
         )
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Localizable {
+    var defaultValue: String.LocalizationValue {
+        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+        for argument in arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        return String.LocalizationValue(stringInterpolation: stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -122,7 +122,8 @@ extension String.Localizable {
                 stringInterpolation.appendInterpolation(value)
             }
         }
-        return String.LocalizationValue(stringInterpolation: stringInterpolation)
+        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+        return makeDefaultValue(stringInterpolation)
     }
 }
 


### PR DESCRIPTION
Closes #64 

Starting in 0.2.0, the generated source defines `String.LocalizationValue` literals that act as the `defaultValue` when creating instances of `LocalizedStringResource`.

Previously, these values didn't seem to be picked up by Xcode, but with the changes in #50, Xcode seems to pick these up and will put them into your Strings Catalog as a new phrase, which is not what we want.

The `defaultValue` is required as this is the only way to pass the values for each argument into `LocalizedStringResource`, so we can't omit it, but there are alternative ways to generate the source code that prevent it from being detected by Xcode's string extraction...

Since the only way to initialise `String.LocalizationValue` with arguments is to use string interpolation (sugar for `init(stringInterpolation:)`), we construct the value dynamically by manually initializing a `String.LocalizationValue.StringInterpolation` type and then we pass that type into the initialiser... it was that or to (ab)use the `Decodable` conformance.

This means that the generated code will now store an array of `Argument` types instead of `String.LocalizationValue` directly, thus fixing the reported issue.

This also brings some other future benefits, such as breaking away from iOS 15 minimum and allowing `Sendable` and `Equatable` conformance.. I'll bring those features in a future Pull Request 👍 