### PR TITLE
Include the source localisation value in the headerdoc comments

### DIFF
--- a/Sources/StringExtractor/Resource+Extract.swift
+++ b/Sources/StringExtractor/Resource+Extract.swift
@@ -5,17 +5,17 @@ extension Resource {
         from segments: [StringParser.ParsedSegment],
         labels: [Int: String] = [:],
         key: String
-    ) throws -> (arguments: [Argument], defaultValue: [StringSegment]) {
-        var defaultValue: [StringSegment] = [], arguments: [Int: Argument] = [:]
+    ) throws -> (arguments: [Argument], defaultValue: String) {
+        var defaultValue: String = "", arguments: [Int: Argument] = [:]
         var nextUnspecifiedPosition = 1
 
         // Convert the parsed string into a default value and extract the arguments
         for segment in segments {
             switch segment {
             case .string(let contents):
-                defaultValue.append(.string(contents))
+                defaultValue.append(contents)
             case .placeholder(let placeholder) where placeholder.rawValue == "%" || placeholder.rawValue == "%%":
-                defaultValue.append(.string(placeholder.rawValue))
+                defaultValue.append(placeholder.rawValue)
             case .placeholder(let placeholder):
                 // If the placeholder is an unsupported type, raise an error about the invalid string
                 guard let _type = placeholder.type, let type = String.LocalizationValue.Placeholder(_type) else {
@@ -61,7 +61,7 @@ extension Resource {
                     )
                 }
 
-                defaultValue.append(.interpolation(name))
+                defaultValue.append(placeholder.rawValue)
                 arguments[position] = argument
             }
         }

--- a/Sources/StringExtractor/Resource+Extract.swift
+++ b/Sources/StringExtractor/Resource+Extract.swift
@@ -5,17 +5,17 @@ extension Resource {
         from segments: [StringParser.ParsedSegment],
         labels: [Int: String] = [:],
         key: String
-    ) throws -> (arguments: [Argument], defaultValue: String) {
-        var defaultValue: String = "", arguments: [Int: Argument] = [:]
+    ) throws -> (arguments: [Argument], sourceLocalization: String) {
+        var sourceLocalization: String = "", arguments: [Int: Argument] = [:]
         var nextUnspecifiedPosition = 1
 
         // Convert the parsed string into a default value and extract the arguments
         for segment in segments {
             switch segment {
             case .string(let contents):
-                defaultValue.append(contents)
+                sourceLocalization.append(contents)
             case .placeholder(let placeholder) where placeholder.rawValue == "%" || placeholder.rawValue == "%%":
-                defaultValue.append(placeholder.rawValue)
+                sourceLocalization.append(placeholder.rawValue)
             case .placeholder(let placeholder):
                 // If the placeholder is an unsupported type, raise an error about the invalid string
                 guard let _type = placeholder.type, let type = String.LocalizationValue.Placeholder(_type) else {
@@ -61,7 +61,7 @@ extension Resource {
                     )
                 }
 
-                defaultValue.append(placeholder.rawValue)
+                sourceLocalization.append(placeholder.rawValue)
                 arguments[position] = argument
             }
         }
@@ -81,7 +81,7 @@ extension Resource {
             }
         }
 
-        return (arguments.sorted(by: { $0.key < $1.key }).map(\.value), defaultValue)
+        return (arguments.sorted(by: { $0.key < $1.key }).map(\.value), sourceLocalization)
     }
 }
 

--- a/Sources/StringExtractor/Resource+StringUnit.swift
+++ b/Sources/StringExtractor/Resource+StringUnit.swift
@@ -20,7 +20,7 @@ extension Resource {
     static func extract(
         from localization: StringLocalization,
         key: String
-    ) throws -> (arguments: [Argument], defaultValue: [StringSegment]) {
+    ) throws -> (arguments: [Argument], defaultValue: String) {
         guard let stringUnit = preferredStringUnit(from: localization.stringUnit, variations: localization.variations) else {
             throw ExtractionError.localizationCorrupt(
                 ExtractionError.Context(

--- a/Sources/StringExtractor/Resource+StringUnit.swift
+++ b/Sources/StringExtractor/Resource+StringUnit.swift
@@ -13,14 +13,14 @@ extension Resource {
             comment: comment,
             identifier: identifier,
             arguments: extracted.arguments,
-            defaultValue: extracted.defaultValue
+            sourceLocalization: extracted.sourceLocalization
         )
     }
 
     static func extract(
         from localization: StringLocalization,
         key: String
-    ) throws -> (arguments: [Argument], defaultValue: String) {
+    ) throws -> (arguments: [Argument], sourceLocalization: String) {
         guard let stringUnit = preferredStringUnit(from: localization.stringUnit, variations: localization.variations) else {
             throw ExtractionError.localizationCorrupt(
                 ExtractionError.Context(

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -1031,7 +1031,7 @@ public struct StringGenerator {
     var typeDocumentation: Trivia {
         let exampleResource = resources.first(where: { $0.arguments.isEmpty })
         let exampleId = exampleResource?.identifier ?? "foo"
-        let exampleValue = exampleResource?.defaultValue.map(\.content).reduce("", +) ?? "bar"
+        let exampleValue = exampleResource?.defaultValue ?? "bar"
         let exampleAccessor = ".\(variableToken.text).\(exampleId)"
 
         return Trivia(docComment: """
@@ -1053,7 +1053,7 @@ public struct StringGenerator {
     var customTypeDocumentation: Trivia {
         let exampleResource = resources.first(where: { $0.arguments.isEmpty })
         let exampleId = exampleResource?.identifier ?? "foo"
-        let exampleValue = exampleResource?.defaultValue.map(\.content).reduce("", +) ?? "bar"
+        let exampleValue = exampleResource?.defaultValue ?? "bar"
 
         return Trivia(docComment: """
         Constant values for the \(tableName) Strings Catalog

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -1180,16 +1180,21 @@ extension Resource {
     }
 
     var leadingTrivia: Trivia {
-        var trivia: Trivia = .init(pieces: [])
+        var docComponents: [String] = []
 
-        if let commentLines = comment?.components(separatedBy: .newlines), !commentLines.isEmpty {
-            for line in commentLines {
-                trivia = trivia.appending(Trivia.docLineComment("/// \(line)"))
-                trivia = trivia.appending(.newline)
-            }
+        if let comment {
+            docComponents.append(comment)
         }
 
-        return trivia
+        docComponents.append("""
+        ### Source Localization
+
+        ```
+        \(sourceLocalization)
+        ```
+        """)
+
+        return Trivia(docComment: docComponents.joined(separator: "\n\n"))
     }
 
     func statements(

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -1031,7 +1031,7 @@ public struct StringGenerator {
     var typeDocumentation: Trivia {
         let exampleResource = resources.first(where: { $0.arguments.isEmpty })
         let exampleId = exampleResource?.identifier ?? "foo"
-        let exampleValue = exampleResource?.defaultValue ?? "bar"
+        let exampleValue = exampleResource?.sourceLocalization ?? "bar"
         let exampleAccessor = ".\(variableToken.text).\(exampleId)"
 
         return Trivia(docComment: """
@@ -1053,7 +1053,7 @@ public struct StringGenerator {
     var customTypeDocumentation: Trivia {
         let exampleResource = resources.first(where: { $0.arguments.isEmpty })
         let exampleId = exampleResource?.identifier ?? "foo"
-        let exampleValue = exampleResource?.defaultValue ?? "bar"
+        let exampleValue = exampleResource?.sourceLocalization ?? "bar"
 
         return Trivia(docComment: """
         Constant values for the \(tableName) Strings Catalog

--- a/Sources/StringResource/Resource.swift
+++ b/Sources/StringResource/Resource.swift
@@ -13,21 +13,21 @@ public struct Resource: Equatable {
     /// An array of arguments to be interpolated into the resource
     public let arguments: [Argument]
 
-    /// The default localised value
-    public let defaultValue: String
+    /// The source localization value
+    public let sourceLocalization: String
 
     public init(
         key: String,
         comment: String?,
         identifier: String,
         arguments: [Argument],
-        defaultValue: String
+        sourceLocalization: String
     ) {
         self.key = key
         self.comment = comment
         self.identifier = identifier
         self.arguments = arguments
-        self.defaultValue = defaultValue
+        self.sourceLocalization = sourceLocalization
     }
 }
 

--- a/Sources/StringResource/Resource.swift
+++ b/Sources/StringResource/Resource.swift
@@ -13,15 +13,15 @@ public struct Resource: Equatable {
     /// An array of arguments to be interpolated into the resource
     public let arguments: [Argument]
 
-    /// The string segments that make up the string literal to be used as the default value
-    public let defaultValue: [StringSegment]
+    /// The default localised value
+    public let defaultValue: String
 
     public init(
         key: String,
         comment: String?,
         identifier: String,
         arguments: [Argument],
-        defaultValue: [StringSegment]
+        defaultValue: String
     ) {
         self.key = key
         self.comment = comment

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -58,6 +58,12 @@ extension String {
 
 extension String.FormatSpecifiers {
     /// %@ should convert to a String argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %@
+    /// ```
     internal static func at(_ arg1: String) -> Self {
         Self (
             key: "at",
@@ -71,6 +77,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %d should convert to an Int argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %d
+    /// ```
     internal static func d(_ arg1: Int) -> Self {
         Self (
             key: "d",
@@ -84,6 +96,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %lld should covert to an Int
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %lld
+    /// ```
     internal static func d_length(_ arg1: Int) -> Self {
         Self (
             key: "d_length",
@@ -97,6 +115,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %f should convert to a Double argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %f
+    /// ```
     internal static func f(_ arg1: Double) -> Self {
         Self (
             key: "f",
@@ -110,6 +134,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %.2f should convert to a Double argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %.2f
+    /// ```
     internal static func f_precision(_ arg1: Double) -> Self {
         Self (
             key: "f_precision",
@@ -123,6 +153,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %i should convert to an Int argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %i
+    /// ```
     internal static func i(_ arg1: Int) -> Self {
         Self (
             key: "i",
@@ -136,6 +172,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %o should convert to a UInt argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %o
+    /// ```
     internal static func o(_ arg1: UInt) -> Self {
         Self (
             key: "o",
@@ -149,6 +191,12 @@ extension String.FormatSpecifiers {
     }
 
     /// % should not be converted to an argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %
+    /// ```
     internal static var percentage: Self {
         Self (
             key: "percentage",
@@ -160,6 +208,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %% should not be converted to an argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %%
+    /// ```
     internal static var percentage_escaped: Self {
         Self (
             key: "percentage_escaped",
@@ -171,6 +225,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %% should not be converted to an argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test 50%% off
+    /// ```
     internal static var percentage_escaped_space_o: Self {
         Self (
             key: "percentage_escaped_space_o",
@@ -182,6 +242,12 @@ extension String.FormatSpecifiers {
     }
 
     /// '% o' should not be converted to an argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test 50% off
+    /// ```
     internal static var percentage_space_o: Self {
         Self (
             key: "percentage_space_o",
@@ -193,6 +259,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %u should convert to a UInt argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %u
+    /// ```
     internal static func u(_ arg1: UInt) -> Self {
         Self (
             key: "u",
@@ -206,6 +278,12 @@ extension String.FormatSpecifiers {
     }
 
     /// %x should convert to a UInt argument
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Test %x
+    /// ```
     internal static func x(_ arg1: UInt) -> Self {
         Self (
             key: "x",
@@ -302,66 +380,144 @@ extension LocalizedStringResource {
     /// - Note: Using ``LocalizedStringResource.FormatSpecifiers`` requires iOS 16/macOS 13 or later. See ``String.FormatSpecifiers`` for an iOS 15/macOS 12 compatible API.
     internal struct FormatSpecifiers {
         /// %@ should convert to a String argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %@
+        /// ```
         internal func at(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .at(arg1))
         }
 
         /// %d should convert to an Int argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %d
+        /// ```
         internal func d(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d(arg1))
         }
 
         /// %lld should covert to an Int
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %lld
+        /// ```
         internal func d_length(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d_length(arg1))
         }
 
         /// %f should convert to a Double argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %f
+        /// ```
         internal func f(_ arg1: Double) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .f(arg1))
         }
 
         /// %.2f should convert to a Double argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %.2f
+        /// ```
         internal func f_precision(_ arg1: Double) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .f_precision(arg1))
         }
 
         /// %i should convert to an Int argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %i
+        /// ```
         internal func i(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .i(arg1))
         }
 
         /// %o should convert to a UInt argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %o
+        /// ```
         internal func o(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .o(arg1))
         }
 
         /// % should not be converted to an argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %
+        /// ```
         internal var percentage: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage)
         }
 
         /// %% should not be converted to an argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %%
+        /// ```
         internal var percentage_escaped: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_escaped)
         }
 
         /// %% should not be converted to an argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test 50%% off
+        /// ```
         internal var percentage_escaped_space_o: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_escaped_space_o)
         }
 
         /// '% o' should not be converted to an argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test 50% off
+        /// ```
         internal var percentage_space_o: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_space_o)
         }
 
         /// %u should convert to a UInt argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %u
+        /// ```
         internal func u(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .u(arg1))
         }
 
         /// %x should convert to a UInt argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %x
+        /// ```
         internal func x(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .x(arg1))
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -58,6 +58,12 @@ extension String {
 
 extension String.Localizable {
     /// This is a comment
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Default Value
+    /// ```
     internal static var key: Self {
         Self (
             key: "Key",
@@ -68,6 +74,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Multiplatform Original
+    /// ```
     internal static var myDeviceVariant: Self {
         Self (
             key: "myDeviceVariant",
@@ -78,6 +89,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// I have %lld plurals
+    /// ```
     internal static func myPlural(_ arg1: Int) -> Self {
         Self (
             key: "myPlural",
@@ -90,6 +106,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// %lld: People liked %lld posts
+    /// ```
     internal static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
         Self (
             key: "mySubstitute",
@@ -187,18 +208,39 @@ extension LocalizedStringResource {
     /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
     internal struct Localizable {
         /// This is a comment
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Default Value
+        /// ```
         internal var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Multiplatform Original
+        /// ```
         internal var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// I have %lld plurals
+        /// ```
         internal func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %lld: People liked %lld posts
+        /// ```
         internal func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -60,6 +60,15 @@ extension String.Multiline {
     /// This example tests the following:
     /// 1. That line breaks in the defaultValue are supported
     /// 2. That line breaks in the comment are supported
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Options:
+    /// - One
+    /// - Two
+    /// - Three
+    /// ```
     internal static var multiline: Self {
         Self (
             key: "multiline",
@@ -156,6 +165,15 @@ extension LocalizedStringResource {
         /// This example tests the following:
         /// 1. That line breaks in the defaultValue are supported
         /// 2. That line breaks in the comment are supported
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Options:
+        /// - One
+        /// - Two
+        /// - Three
+        /// ```
         internal var multiline: LocalizedStringResource {
             LocalizedStringResource(multiline: .multiline)
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -58,6 +58,12 @@ extension String {
 
 extension String.Positional {
     /// A string where the second argument is at the front of the string and the first argument is at the end
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Second: %2$@ - First: %1$lld
+    /// ```
     internal static func reorder(_ arg1: Int, _ arg2: String) -> Self {
         Self (
             key: "reorder",
@@ -72,6 +78,12 @@ extension String.Positional {
     }
 
     /// A string that uses the same argument twice
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// %1$lld, I repeat: %1$lld
+    /// ```
     internal static func repeatExplicit(_ arg1: Int) -> Self {
         Self (
             key: "repeatExplicit",
@@ -85,6 +97,12 @@ extension String.Positional {
     }
 
     /// A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// %@, are you there? %1$@?
+    /// ```
     internal static func repeatImplicit(_ arg1: String) -> Self {
         Self (
             key: "repeatImplicit",
@@ -181,16 +199,34 @@ extension LocalizedStringResource {
     /// - Note: Using ``LocalizedStringResource.Positional`` requires iOS 16/macOS 13 or later. See ``String.Positional`` for an iOS 15/macOS 12 compatible API.
     internal struct Positional {
         /// A string where the second argument is at the front of the string and the first argument is at the end
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Second: %2$@ - First: %1$lld
+        /// ```
         internal func reorder(_ arg1: Int, _ arg2: String) -> LocalizedStringResource {
             LocalizedStringResource(positional: .reorder(arg1, arg2))
         }
 
         /// A string that uses the same argument twice
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %1$lld, I repeat: %1$lld
+        /// ```
         internal func repeatExplicit(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(positional: .repeatExplicit(arg1))
         }
 
         /// A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %@, are you there? %1$@?
+        /// ```
         internal func repeatImplicit(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(positional: .repeatImplicit(arg1))
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -58,6 +58,12 @@ extension String {
 
 extension String.Simple {
     /// This is a simple key and value
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// My Value
+    /// ```
     internal static var simpleKey: Self {
         Self (
             key: "SimpleKey",
@@ -152,6 +158,12 @@ extension LocalizedStringResource {
     /// - Note: Using ``LocalizedStringResource.Simple`` requires iOS 16/macOS 13 or later. See ``String.Simple`` for an iOS 15/macOS 12 compatible API.
     internal struct Simple {
         /// This is a simple key and value
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// My Value
+        /// ```
         internal var simpleKey: LocalizedStringResource {
             LocalizedStringResource(simple: .simpleKey)
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -58,6 +58,12 @@ extension String {
 
 extension String.Substitution {
     /// A string that uses substitutions as well as arguments
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// %@! There are %lld strings and you have %lld remaining
+    /// ```
     internal static func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> Self {
         Self (
             key: "substitutions_example.string",
@@ -156,6 +162,12 @@ extension LocalizedStringResource {
     /// - Note: Using ``LocalizedStringResource.Substitution`` requires iOS 16/macOS 13 or later. See ``String.Substitution`` for an iOS 15/macOS 12 compatible API.
     internal struct Substitution {
         /// A string that uses substitutions as well as arguments
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %@! There are %lld strings and you have %lld remaining
+        /// ```
         internal func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> LocalizedStringResource {
             LocalizedStringResource(substitution: .substitutions_exampleString(arg1, totalStrings: arg2, remainingStrings: arg3))
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -58,6 +58,12 @@ extension String {
 
 extension String.Variations {
     /// A string that should have a macOS variation to replace 'Tap' with 'Click'
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Tap to open
+    /// ```
     internal static var stringDevice: Self {
         Self (
             key: "String.Device",
@@ -68,6 +74,11 @@ extension String.Variations {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// I have %lld strings
+    /// ```
     internal static func stringPlural(_ arg1: Int) -> Self {
         Self (
             key: "String.Plural",
@@ -164,10 +175,21 @@ extension LocalizedStringResource {
     /// - Note: Using ``LocalizedStringResource.Variations`` requires iOS 16/macOS 13 or later. See ``String.Variations`` for an iOS 15/macOS 12 compatible API.
     internal struct Variations {
         /// A string that should have a macOS variation to replace 'Tap' with 'Click'
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Tap to open
+        /// ```
         internal var stringDevice: LocalizedStringResource {
             LocalizedStringResource(variations: .stringDevice)
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// I have %lld strings
+        /// ```
         internal func stringPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(variations: .stringPlural(arg1))
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -58,6 +58,12 @@ extension String {
 
 extension String.Localizable {
     /// This is a comment
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Default Value
+    /// ```
     package static var key: Self {
         Self (
             key: "Key",
@@ -68,6 +74,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Multiplatform Original
+    /// ```
     package static var myDeviceVariant: Self {
         Self (
             key: "myDeviceVariant",
@@ -78,6 +89,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// I have %lld plurals
+    /// ```
     package static func myPlural(_ arg1: Int) -> Self {
         Self (
             key: "myPlural",
@@ -90,6 +106,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// %lld: People liked %lld posts
+    /// ```
     package static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
         Self (
             key: "mySubstitute",
@@ -187,18 +208,39 @@ extension LocalizedStringResource {
     /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
     package struct Localizable {
         /// This is a comment
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Default Value
+        /// ```
         package var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Multiplatform Original
+        /// ```
         package var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// I have %lld plurals
+        /// ```
         package func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %lld: People liked %lld posts
+        /// ```
         package func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -58,6 +58,12 @@ extension String {
 
 extension String.Localizable {
     /// This is a comment
+    ///
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Default Value
+    /// ```
     public static var key: Self {
         Self (
             key: "Key",
@@ -68,6 +74,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// Multiplatform Original
+    /// ```
     public static var myDeviceVariant: Self {
         Self (
             key: "myDeviceVariant",
@@ -78,6 +89,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// I have %lld plurals
+    /// ```
     public static func myPlural(_ arg1: Int) -> Self {
         Self (
             key: "myPlural",
@@ -90,6 +106,11 @@ extension String.Localizable {
         )
     }
 
+    /// ### Source Localization
+    ///
+    /// ```
+    /// %lld: People liked %lld posts
+    /// ```
     public static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
         Self (
             key: "mySubstitute",
@@ -187,18 +208,39 @@ extension LocalizedStringResource {
     /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
     public struct Localizable {
         /// This is a comment
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Default Value
+        /// ```
         public var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Multiplatform Original
+        /// ```
         public var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// I have %lld plurals
+        /// ```
         public func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
 
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %lld: People liked %lld posts
+        /// ```
         public func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }


### PR DESCRIPTION
Closes #68

<img width="469" alt="Screenshot 2024-05-16 at 20 15 17" src="https://github.com/liamnichols/xcstrings-tool/assets/482871/04f3e167-796b-423c-9629-a97f22ae7b3b">

It's useful to see the source localisation, especially now that it's no longer included in the generated code after #67. This change replaces the `Resource.defaultValue` property with a new `sourceLocalization` property and uses it for the `///` doc comment for each generated accessor.