### PR TITLE
Bring support to all OS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ struct ContentView: View {
 
 XCStrings Tool aims to extend your localization experience so that you don't have to compromise anything. It does this by using your Strings Catalog as a source for generating elegant Swift code that you can reference directly within the rest of your project.
 
-> [!NOTE]
->
-> While Strings Catalogs are fully backwards compatible, code generated using XCStrings Tool supports iOS 15/macOS 12/watchOS 8/tvOS 15 or later.
-
 ## Getting Started
 
 XCStrings Tool is a Swift Package Plugin that can integrate directly into Xcode and Swift Package targets that contain Strings Catalog (.xcstrings) files.

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -1156,7 +1156,7 @@ public struct StringGenerator {
         Text(\(exampleAccessor))
         ```
 
-        - Note: Using ``LocalizedStringResource.\(tableName)`` requires iOS 16/macOS 13 or later. See ``String.\(tableName)`` for an iOS 15/macOS 12 compatible API.
+        - Note: Using ``LocalizedStringResource.\(tableName)`` requires iOS 16/macOS 13 or later. See ``String.\(tableName)`` for a backwards compatible API.
         """)
     }
 

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -310,6 +310,51 @@ public struct StringGenerator {
                     }
                 )
             ) {
+                // let bundle: Bundle = .from(description: localizable.bundle) ?? .main
+                VariableDeclSyntax(bindingSpecifier: .keyword(.let)) {
+                    PatternBindingSyntax(
+                        pattern: IdentifierPatternSyntax(identifier: "bundle"),
+                        typeAnnotation: TypeAnnotationSyntax(
+                            type: IdentifierTypeSyntax(name: .type(.Bundle))
+                        ),
+                        initializer: InitializerClauseSyntax(
+                            value: InfixOperatorExprSyntax(
+                                leftOperand: FunctionCallExprSyntax(
+                                    callee: MemberAccessExprSyntax(name: "from")
+                                ) {
+                                    LabeledExprSyntax(
+                                        label: "description",
+                                        expression: MemberAccessExprSyntax(
+                                            base: DeclReferenceExprSyntax(baseName: variableToken),
+                                            name: "bundle"
+                                        )
+                                    )
+                                },
+                                operator: BinaryOperatorExprSyntax(operator: .binaryOperator("??")),
+                                rightOperand: MemberAccessExprSyntax(name: "main")
+                            )
+                        )
+                    )
+                }
+                // let key = String(describing: localizable.key)
+                VariableDeclSyntax(bindingSpecifier: .keyword(.let)) {
+                    PatternBindingSyntax(
+                        pattern: IdentifierPatternSyntax(identifier: "key"),
+                        initializer: InitializerClauseSyntax(
+                            value: FunctionCallExprSyntax(
+                                callee: DeclReferenceExprSyntax(baseName: .type(.String))
+                            ) {
+                                LabeledExprSyntax(
+                                    label: "describing",
+                                    expression: MemberAccessExprSyntax(
+                                        base: DeclReferenceExprSyntax(baseName: variableToken),
+                                        name: "key"
+                                    )
+                                )
+                            }
+                        )
+                    )
+                }
                 // self.init(format:locale:arguments:)
                 FunctionCallExprSyntax(
                     callee: MemberAccessExprSyntax(
@@ -317,62 +362,36 @@ public struct StringGenerator {
                         name: .keyword(.`init`)
                     )
                 ) {
-                    // format: NSLocalizedString(...)
+                    // format: bundle.localizedString(forKey: key, value: nil, table: localizable.table),
                     LabeledExprSyntax(
                         label: "format",
                         expression: FunctionCallExprSyntax(
-                            callee: DeclReferenceExprSyntax(baseName: "NSLocalizedString")
-                        ) {
-                            // String(describing: localizable.key),
-                            LabeledExprSyntax(
-                                expression: FunctionCallExprSyntax(
-                                    callee: DeclReferenceExprSyntax(baseName: .type(.String))
-                                ) {
-                                    LabeledExprSyntax(
-                                        label: "describing",
-                                        expression: MemberAccessExprSyntax(
-                                            base: DeclReferenceExprSyntax(baseName: variableToken),
-                                            name: "key"
-                                        )
-                                    )
-                                }
+                            callee: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: "bundle"),
+                                name: "localizedString"
                             )
-                            // tableName: localizable.table,
+                        ) {
+                            // forKey: key,
                             LabeledExprSyntax(
-                                label: "tableName",
+                                label: "forKey",
+                                expression: DeclReferenceExprSyntax(baseName: "key")
+                            )
+                            // value: nil,
+                            LabeledExprSyntax(
+                                label: "value",
+                                expression: NilLiteralExprSyntax()
+                            )
+                            // table: localizable.table
+                            LabeledExprSyntax(
+                                label: "table",
                                 expression: MemberAccessExprSyntax(
                                     base: DeclReferenceExprSyntax(baseName: variableToken),
                                     name: "table"
                                 )
                             )
-                            // bundle: .from(description: substitution.bundle) ?? .main,
-                            LabeledExprSyntax(
-                                label: "bundle",
-                                expression: InfixOperatorExprSyntax(
-                                    leftOperand: FunctionCallExprSyntax(
-                                        callee: MemberAccessExprSyntax(name: "from")
-                                    ) {
-                                        LabeledExprSyntax(
-                                            label: "description",
-                                            expression: MemberAccessExprSyntax(
-                                                base: DeclReferenceExprSyntax(baseName: variableToken),
-                                                name: "bundle"
-                                            )
-                                        )
-                                    },
-                                    operator: BinaryOperatorExprSyntax(operator: .binaryOperator("??")),
-                                    rightOperand: MemberAccessExprSyntax(name: "main")
-                                )
-                            )
-                            // comment: ""
-                            LabeledExprSyntax(
-                                label: "comment",
-                                expression: StringLiteralExprSyntax(content: "")
-                            )
                         }
-                        .multiline()
                     )
-                    // locale: locale
+                    // locale: locale,
                     LabeledExprSyntax(
                         label: "locale",
                         expression: DeclReferenceExprSyntax(baseName: "locale")

--- a/Sources/StringGenerator/SwiftSyntax/TokenSyntax+Types.swift
+++ b/Sources/StringGenerator/SwiftSyntax/TokenSyntax+Types.swift
@@ -12,6 +12,7 @@ extension TokenSyntax {
         case BundleDescription
         case LocalizedStringResource
         case Argument
+        case CVarArg
     }
 
     static func type(_ value: MetaType) -> TokenSyntax {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(formatSpecifiers: FormatSpecifiers, locale: Locale? = nil) {
         self.init(
-            localized: formatSpecifiers.key,
-            defaultValue: formatSpecifiers.defaultValue,
-            table: formatSpecifiers.table,
-            bundle: .from(description: formatSpecifiers.bundle),
-            locale: locale ?? formatSpecifiers.locale
+            format: NSLocalizedString(
+                String(describing: formatSpecifiers.key),
+                tableName: formatSpecifiers.table,
+                bundle: .from(description: formatSpecifiers.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: formatSpecifiers.arguments.map(\.value)
         )
     }
 }
@@ -298,7 +300,7 @@ extension String.FormatSpecifiers {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.FormatSpecifiers {
+private extension String.FormatSpecifiers {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -320,7 +322,23 @@ extension String.FormatSpecifiers {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.FormatSpecifiers.Argument {
+    var value: CVarArg {
+        switch self {
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .float(let value):
+            value
+        case .double(let value):
+            value
+        case .object(let value):
+            value
+        }
+    }
+}
+
 private extension String.FormatSpecifiers.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -336,7 +354,6 @@ private extension String.FormatSpecifiers.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.FormatSpecifiers.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     internal init(formatSpecifiers: FormatSpecifiers, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: formatSpecifiers.bundle) ?? .main
+        let key = String(describing: formatSpecifiers.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: formatSpecifiers.key),
-                tableName: formatSpecifiers.table,
-                bundle: .from(description: formatSpecifiers.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: formatSpecifiers.table),
             locale: locale,
             arguments: formatSpecifiers.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -391,7 +391,7 @@ extension LocalizedStringResource {
     /// Text(.formatSpecifiers.percentage)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.FormatSpecifiers`` requires iOS 16/macOS 13 or later. See ``String.FormatSpecifiers`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.FormatSpecifiers`` requires iOS 16/macOS 13 or later. See ``String.FormatSpecifiers`` for a backwards compatible API.
     internal struct FormatSpecifiers {
         /// %@ should convert to a String argument
         ///

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -219,7 +219,7 @@ extension LocalizedStringResource {
     /// Text(.localizable.key)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for a backwards compatible API.
     internal struct Localizable {
         /// This is a comment
         ///

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     internal init(localizable: Localizable, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: localizable.bundle) ?? .main
+        let key = String(describing: localizable.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: localizable.key),
-                tableName: localizable.table,
-                bundle: .from(description: localizable.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: localizable.table),
             locale: locale,
             arguments: localizable.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
-            localized: localizable.key,
-            defaultValue: localizable.defaultValue,
-            table: localizable.table,
-            bundle: .from(description: localizable.bundle),
-            locale: locale ?? localizable.locale
+            format: NSLocalizedString(
+                String(describing: localizable.key),
+                tableName: localizable.table,
+                bundle: .from(description: localizable.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: localizable.arguments.map(\.value)
         )
     }
 }
@@ -126,7 +128,7 @@ extension String.Localizable {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.Localizable {
+private extension String.Localizable {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -148,7 +150,23 @@ extension String.Localizable {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Localizable.Argument {
+    var value: CVarArg {
+        switch self {
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .float(let value):
+            value
+        case .double(let value):
+            value
+        case .object(let value):
+            value
+        }
+    }
+}
+
 private extension String.Localizable.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -164,7 +182,6 @@ private extension String.Localizable.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.Localizable.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     internal init(multiline: Multiline, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: multiline.bundle) ?? .main
+        let key = String(describing: multiline.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: multiline.key),
-                tableName: multiline.table,
-                bundle: .from(description: multiline.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: multiline.table),
             locale: locale,
             arguments: multiline.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(multiline: Multiline, locale: Locale? = nil) {
         self.init(
-            localized: multiline.key,
-            defaultValue: multiline.defaultValue,
-            table: multiline.table,
-            bundle: .from(description: multiline.bundle),
-            locale: locale ?? multiline.locale
+            format: NSLocalizedString(
+                String(describing: multiline.key),
+                tableName: multiline.table,
+                bundle: .from(description: multiline.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: multiline.arguments.map(\.value)
         )
     }
 }
@@ -81,7 +83,7 @@ extension String.Multiline {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.Multiline {
+private extension String.Multiline {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -103,7 +105,23 @@ extension String.Multiline {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Multiline.Argument {
+    var value: CVarArg {
+        switch self {
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .float(let value):
+            value
+        case .double(let value):
+            value
+        case .object(let value):
+            value
+        }
+    }
+}
+
 private extension String.Multiline.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -119,7 +137,6 @@ private extension String.Multiline.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.Multiline.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -174,7 +174,7 @@ extension LocalizedStringResource {
     /// Text(.multiline.multiline)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.Multiline`` requires iOS 16/macOS 13 or later. See ``String.Multiline`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.Multiline`` requires iOS 16/macOS 13 or later. See ``String.Multiline`` for a backwards compatible API.
     internal struct Multiline {
         /// This example tests the following:
         /// 1. That line breaks in the defaultValue are supported

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(positional: Positional, locale: Locale? = nil) {
         self.init(
-            localized: positional.key,
-            defaultValue: positional.defaultValue,
-            table: positional.table,
-            bundle: .from(description: positional.bundle),
-            locale: locale ?? positional.locale
+            format: NSLocalizedString(
+                String(describing: positional.key),
+                tableName: positional.table,
+                bundle: .from(description: positional.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: positional.arguments.map(\.value)
         )
     }
 }
@@ -117,7 +119,7 @@ extension String.Positional {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.Positional {
+private extension String.Positional {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -139,7 +141,23 @@ extension String.Positional {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Positional.Argument {
+    var value: CVarArg {
+        switch self {
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .float(let value):
+            value
+        case .double(let value):
+            value
+        case .object(let value):
+            value
+        }
+    }
+}
+
 private extension String.Positional.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -155,7 +173,6 @@ private extension String.Positional.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.Positional.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -210,7 +210,7 @@ extension LocalizedStringResource {
     /// Text(.positional.foo)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.Positional`` requires iOS 16/macOS 13 or later. See ``String.Positional`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.Positional`` requires iOS 16/macOS 13 or later. See ``String.Positional`` for a backwards compatible API.
     internal struct Positional {
         /// A string where the second argument is at the front of the string and the first argument is at the end
         ///

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     internal init(positional: Positional, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: positional.bundle) ?? .main
+        let key = String(describing: positional.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: positional.key),
-                tableName: positional.table,
-                bundle: .from(description: positional.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: positional.table),
             locale: locale,
             arguments: positional.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -169,7 +169,7 @@ extension LocalizedStringResource {
     /// Text(.simple.simpleKey)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.Simple`` requires iOS 16/macOS 13 or later. See ``String.Simple`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.Simple`` requires iOS 16/macOS 13 or later. See ``String.Simple`` for a backwards compatible API.
     internal struct Simple {
         /// This is a simple key and value
         ///

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(simple: Simple, locale: Locale? = nil) {
         self.init(
-            localized: simple.key,
-            defaultValue: simple.defaultValue,
-            table: simple.table,
-            bundle: .from(description: simple.bundle),
-            locale: locale ?? simple.locale
+            format: NSLocalizedString(
+                String(describing: simple.key),
+                tableName: simple.table,
+                bundle: .from(description: simple.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: simple.arguments.map(\.value)
         )
     }
 }
@@ -76,7 +78,7 @@ extension String.Simple {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.Simple {
+private extension String.Simple {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -98,7 +100,23 @@ extension String.Simple {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Simple.Argument {
+    var value: CVarArg {
+        switch self {
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .float(let value):
+            value
+        case .double(let value):
+            value
+        case .object(let value):
+            value
+        }
+    }
+}
+
 private extension String.Simple.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -114,7 +132,6 @@ private extension String.Simple.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.Simple.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     internal init(simple: Simple, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: simple.bundle) ?? .main
+        let key = String(describing: simple.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: simple.key),
-                tableName: simple.table,
-                bundle: .from(description: simple.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: simple.table),
             locale: locale,
             arguments: simple.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(substitution: Substitution, locale: Locale? = nil) {
         self.init(
-            localized: substitution.key,
-            defaultValue: substitution.defaultValue,
-            table: substitution.table,
-            bundle: .from(description: substitution.bundle),
-            locale: locale ?? substitution.locale
+            format: NSLocalizedString(
+                String(describing: substitution.key),
+                tableName: substitution.table,
+                bundle: .from(description: substitution.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: substitution.arguments.map(\.value)
         )
     }
 }
@@ -80,7 +82,7 @@ extension String.Substitution {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.Substitution {
+private extension String.Substitution {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -102,7 +104,23 @@ extension String.Substitution {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Substitution.Argument {
+    var value: CVarArg {
+        switch self {
+        case .object(let value):
+            value
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .double(let value):
+            value
+        case .float(let value):
+            value
+        }
+    }
+}
+
 private extension String.Substitution.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -118,7 +136,6 @@ private extension String.Substitution.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.Substitution.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -107,15 +107,15 @@ private extension String.Substitution {
 private extension String.Substitution.Argument {
     var value: CVarArg {
         switch self {
-        case .object(let value):
-            value
         case .int(let value):
             value
         case .uint(let value):
             value
+        case .float(let value):
+            value
         case .double(let value):
             value
-        case .float(let value):
+        case .object(let value):
             value
         }
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -173,7 +173,7 @@ extension LocalizedStringResource {
     /// Text(.substitution.foo)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.Substitution`` requires iOS 16/macOS 13 or later. See ``String.Substitution`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.Substitution`` requires iOS 16/macOS 13 or later. See ``String.Substitution`` for a backwards compatible API.
     internal struct Substitution {
         /// A string that uses substitutions as well as arguments
         ///

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     internal init(substitution: Substitution, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: substitution.bundle) ?? .main
+        let key = String(describing: substitution.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: substitution.key),
-                tableName: substitution.table,
-                bundle: .from(description: substitution.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: substitution.table),
             locale: locale,
             arguments: substitution.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     internal init(variations: Variations, locale: Locale? = nil) {
         self.init(
-            localized: variations.key,
-            defaultValue: variations.defaultValue,
-            table: variations.table,
-            bundle: .from(description: variations.bundle),
-            locale: locale ?? variations.locale
+            format: NSLocalizedString(
+                String(describing: variations.key),
+                tableName: variations.table,
+                bundle: .from(description: variations.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: variations.arguments.map(\.value)
         )
     }
 }
@@ -93,7 +95,7 @@ extension String.Variations {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.Variations {
+private extension String.Variations {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -115,7 +117,23 @@ extension String.Variations {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Variations.Argument {
+    var value: CVarArg {
+        switch self {
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .float(let value):
+            value
+        case .double(let value):
+            value
+        case .object(let value):
+            value
+        }
+    }
+}
+
 private extension String.Variations.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -131,7 +149,6 @@ private extension String.Variations.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.Variations.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -186,7 +186,7 @@ extension LocalizedStringResource {
     /// Text(.variations.stringDevice)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.Variations`` requires iOS 16/macOS 13 or later. See ``String.Variations`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.Variations`` requires iOS 16/macOS 13 or later. See ``String.Variations`` for a backwards compatible API.
     internal struct Variations {
         /// A string that should have a macOS variation to replace 'Tap' with 'Click'
         ///

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     internal init(variations: Variations, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: variations.bundle) ?? .main
+        let key = String(describing: variations.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: variations.key),
-                tableName: variations.table,
-                bundle: .from(description: variations.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: variations.table),
             locale: locale,
             arguments: variations.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     package init(localizable: Localizable, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: localizable.bundle) ?? .main
+        let key = String(describing: localizable.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: localizable.key),
-                tableName: localizable.table,
-                bundle: .from(description: localizable.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: localizable.table),
             locale: locale,
             arguments: localizable.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     package init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
-            localized: localizable.key,
-            defaultValue: localizable.defaultValue,
-            table: localizable.table,
-            bundle: .from(description: localizable.bundle),
-            locale: locale ?? localizable.locale
+            format: NSLocalizedString(
+                String(describing: localizable.key),
+                tableName: localizable.table,
+                bundle: .from(description: localizable.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: localizable.arguments.map(\.value)
         )
     }
 }
@@ -126,7 +128,7 @@ extension String.Localizable {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.Localizable {
+private extension String.Localizable {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -148,7 +150,23 @@ extension String.Localizable {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Localizable.Argument {
+    var value: CVarArg {
+        switch self {
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .float(let value):
+            value
+        case .double(let value):
+            value
+        case .object(let value):
+            value
+        }
+    }
+}
+
 private extension String.Localizable.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -164,7 +182,6 @@ private extension String.Localizable.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.Localizable.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -219,7 +219,7 @@ extension LocalizedStringResource {
     /// Text(.localizable.key)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for a backwards compatible API.
     package struct Localizable {
         /// This is a comment
         ///

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -44,14 +44,16 @@ extension String {
         }
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public init(localizable: Localizable, locale: Locale? = nil) {
         self.init(
-            localized: localizable.key,
-            defaultValue: localizable.defaultValue,
-            table: localizable.table,
-            bundle: .from(description: localizable.bundle),
-            locale: locale ?? localizable.locale
+            format: NSLocalizedString(
+                String(describing: localizable.key),
+                tableName: localizable.table,
+                bundle: .from(description: localizable.bundle) ?? .main,
+                comment: ""
+            ),
+            locale: locale,
+            arguments: localizable.arguments.map(\.value)
         )
     }
 }
@@ -126,7 +128,7 @@ extension String.Localizable {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension String.Localizable {
+private extension String.Localizable {
     var defaultValue: String.LocalizationValue {
         var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
         for argument in arguments {
@@ -148,7 +150,23 @@ extension String.Localizable {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private extension String.Localizable.Argument {
+    var value: CVarArg {
+        switch self {
+        case .int(let value):
+            value
+        case .uint(let value):
+            value
+        case .float(let value):
+            value
+        case .double(let value):
+            value
+        case .object(let value):
+            value
+        }
+    }
+}
+
 private extension String.Localizable.BundleDescription {
     #if !SWIFT_PACKAGE
     private class BundleLocator {
@@ -164,7 +182,6 @@ private extension String.Localizable.BundleDescription {
     }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 private extension Bundle {
     static func from(description: String.Localizable.BundleDescription) -> Bundle? {
         switch description {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -45,13 +45,10 @@ extension String {
     }
 
     public init(localizable: Localizable, locale: Locale? = nil) {
+        let bundle: Bundle = .from(description: localizable.bundle) ?? .main
+        let key = String(describing: localizable.key)
         self.init(
-            format: NSLocalizedString(
-                String(describing: localizable.key),
-                tableName: localizable.table,
-                bundle: .from(description: localizable.bundle) ?? .main,
-                comment: ""
-            ),
+            format: bundle.localizedString(forKey: key, value: nil, table: localizable.table),
             locale: locale,
             arguments: localizable.arguments.map(\.value)
         )

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -219,7 +219,7 @@ extension LocalizedStringResource {
     /// Text(.localizable.key)
     /// ```
     ///
-    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for an iOS 15/macOS 12 compatible API.
+    /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for a backwards compatible API.
     public struct Localizable {
         /// This is a comment
         ///


### PR DESCRIPTION
In #50, we extended support to iOS 15+ by using `String.init(localized:defaultValue:table:bundle:locale:)`, but it turned out that there was no advantage to using this initialiser over using the original `String.init(format:locale:arguments:)` combined with `Bundle.localizedString(forKey:value:table:)`.

I thought that there was originally because I thought that the newer init allowed you to override the language with the `locale` argument, but it turned out that the `locale` is only used for formatting arguments (i.e decimals) and nothing else.

As a result, I have switched the generated code to use `String.init(format:locale:arguments:)`, which means that it will work across all OS versions now 🚀 

The only version constrained code is the use of `LocalizedStringResource`