### PR TITLE
Expose properties from generated structs for custom use

### DIFF
--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -70,9 +70,6 @@ public struct StringGenerator {
             ) {
                 // BundleDescription
                 EnumDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: .keyword(.fileprivate))
-                    ],
                     name: .type(.BundleDescription),
                     memberBlockBuilder: {
                         EnumCaseDeclSyntax {
@@ -104,9 +101,6 @@ public struct StringGenerator {
 
                 // Argument
                 EnumDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: .keyword(.fileprivate))
-                    ],
                     name: .type(.Argument),
                     memberBlockBuilder: {
                         // case object(String)
@@ -170,9 +164,6 @@ public struct StringGenerator {
 
                 // Properties
                 VariableDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: .keyword(.fileprivate)),
-                    ],
                     .let,
                     name: PatternSyntax(IdentifierPatternSyntax(identifier: "key")),
                     type: TypeAnnotationSyntax(
@@ -180,9 +171,6 @@ public struct StringGenerator {
                     )
                 )
                 VariableDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: .keyword(.fileprivate)),
-                    ],
                     .let,
                     name: PatternSyntax(IdentifierPatternSyntax(identifier: "arguments")),
                     type: TypeAnnotationSyntax(
@@ -190,9 +178,6 @@ public struct StringGenerator {
                     )
                 )
                 VariableDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: .keyword(.fileprivate)),
-                    ],
                     .let,
                     name: PatternSyntax(IdentifierPatternSyntax(identifier: "table")),
                     type: TypeAnnotationSyntax(
@@ -200,9 +185,6 @@ public struct StringGenerator {
                     )
                 )
                 VariableDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: .keyword(.fileprivate)),
-                    ],
                     .let,
                     name: PatternSyntax(IdentifierPatternSyntax(identifier: "bundle")),
                     type: TypeAnnotationSyntax(type: .identifier(.BundleDescription))
@@ -575,7 +557,6 @@ public struct StringGenerator {
 
     func generateStringsTableArgumentValueExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            accessLevel: .private,
             extendedType: MemberTypeSyntax(
                 baseType: localTableMemberType,
                 name: .type(.Argument)
@@ -687,7 +668,6 @@ public struct StringGenerator {
 
     func generateBundleExtension() -> ExtensionDeclSyntax {
         ExtensionDeclSyntax(
-            accessLevel: .private,
             extendedType: .identifier(.Bundle)
         ) {
             FunctionDeclSyntax(

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -204,14 +204,6 @@ public struct StringGenerator {
                         DeclModifierSyntax(name: .keyword(.fileprivate)),
                     ],
                     .let,
-                    name: PatternSyntax(IdentifierPatternSyntax(identifier: "locale")),
-                    type: TypeAnnotationSyntax(type: .identifier(.Locale))
-                )
-                VariableDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: .keyword(.fileprivate)),
-                    ],
-                    .let,
                     name: PatternSyntax(IdentifierPatternSyntax(identifier: "bundle")),
                     type: TypeAnnotationSyntax(type: .identifier(.BundleDescription))
                 ).with(\.trailingTrivia, .newlines(2))
@@ -234,10 +226,6 @@ public struct StringGenerator {
                             FunctionParameterSyntax(
                                 firstName: "table",
                                 type: OptionalTypeSyntax(wrappedType: .identifier(.String))
-                            )
-                            FunctionParameterSyntax(
-                                firstName: "locale",
-                                type: .identifier(.Locale)
                             )
                             FunctionParameterSyntax(
                                 firstName: "bundle",
@@ -270,14 +258,6 @@ public struct StringGenerator {
                         ),
                         operator: AssignmentExprSyntax(),
                         rightOperand: DeclReferenceExprSyntax(baseName: "table")
-                    )
-                    InfixOperatorExprSyntax(
-                        leftOperand: MemberAccessExprSyntax(
-                            base: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
-                            name: "locale"
-                        ),
-                        operator: AssignmentExprSyntax(),
-                        rightOperand: DeclReferenceExprSyntax(baseName: "locale")
                     )
                     InfixOperatorExprSyntax(
                         leftOperand: MemberAccessExprSyntax(
@@ -1060,14 +1040,14 @@ public struct StringGenerator {
                         name: .keyword(.`init`)
                     )
                 ) {
+                    // localizable.key,
                     LabeledExprSyntax(
-                        label: nil,
                         expression: MemberAccessExprSyntax(
                             base: DeclReferenceExprSyntax(baseName: variableToken),
                             declName: DeclReferenceExprSyntax(baseName: "key")
                         )
                     )
-
+                    // defaultValue: localizable.defaultValue,
                     LabeledExprSyntax(
                         label: "defaultValue",
                         expression: MemberAccessExprSyntax(
@@ -1075,7 +1055,7 @@ public struct StringGenerator {
                             declName: DeclReferenceExprSyntax(baseName: "defaultValue")
                         )
                     )
-
+                    // table: localizable.table,
                     LabeledExprSyntax(
                         label: "table",
                         expression: MemberAccessExprSyntax(
@@ -1083,15 +1063,7 @@ public struct StringGenerator {
                             declName: DeclReferenceExprSyntax(baseName: "table")
                         )
                     )
-
-                    LabeledExprSyntax(
-                        label: "locale",
-                        expression: MemberAccessExprSyntax(
-                            base: DeclReferenceExprSyntax(baseName: variableToken),
-                            declName: DeclReferenceExprSyntax(baseName: "locale")
-                        )
-                    )
-
+                    // bundle: .from(description: localizable.bundle)
                     LabeledExprSyntax(
                         label: "bundle",
                         expression: FunctionCallExprSyntax(
@@ -1319,22 +1291,18 @@ extension Resource {
                         baseName: .keyword(.Self)
                     )
                 ) {
-                    LabeledExprSyntax(label: "key", expression: keyExpr)
-
-                    LabeledExprSyntax(label: "arguments", expression: argumentsExpr)
-
+                    LabeledExprSyntax(
+                        label: "key",
+                        expression: keyExpr
+                    )
+                    LabeledExprSyntax(
+                        label: "arguments",
+                        expression: argumentsExpr
+                    )
                     LabeledExprSyntax(
                         label: "table",
                         expression: StringLiteralExprSyntax(content: table)
                     )
-
-                    LabeledExprSyntax(
-                        label: "locale",
-                        expression: MemberAccessExprSyntax(
-                            name: .identifier("current")
-                        )
-                    )
-
                     LabeledExprSyntax(
                         label: "bundle",
                         expression: MemberAccessExprSyntax(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -70,7 +67,6 @@ extension String.FormatSpecifiers {
                 .object(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -89,7 +85,6 @@ extension String.FormatSpecifiers {
                 .int(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -108,7 +103,6 @@ extension String.FormatSpecifiers {
                 .int(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -127,7 +121,6 @@ extension String.FormatSpecifiers {
                 .double(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -146,7 +139,6 @@ extension String.FormatSpecifiers {
                 .double(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -165,7 +157,6 @@ extension String.FormatSpecifiers {
                 .int(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -184,7 +175,6 @@ extension String.FormatSpecifiers {
                 .uint(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -201,7 +191,6 @@ extension String.FormatSpecifiers {
             key: "percentage",
             arguments: [],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -218,7 +207,6 @@ extension String.FormatSpecifiers {
             key: "percentage_escaped",
             arguments: [],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -235,7 +223,6 @@ extension String.FormatSpecifiers {
             key: "percentage_escaped_space_o",
             arguments: [],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -252,7 +239,6 @@ extension String.FormatSpecifiers {
             key: "percentage_space_o",
             arguments: [],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -271,7 +257,6 @@ extension String.FormatSpecifiers {
                 .uint(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -290,7 +275,6 @@ extension String.FormatSpecifiers {
                 .uint(arg1)
             ],
             table: "FormatSpecifiers",
-            locale: .current,
             bundle: .current
         )
     }
@@ -542,7 +526,6 @@ extension LocalizedStringResource {
             formatSpecifiers.key,
             defaultValue: formatSpecifiers.defaultValue,
             table: formatSpecifiers.table,
-            locale: formatSpecifiers.locale,
             bundle: .from(description: formatSpecifiers.bundle)
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "Test %"
     /// ```
     internal struct FormatSpecifiers {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -303,7 +303,7 @@ private extension String.FormatSpecifiers {
     }
 }
 
-private extension String.FormatSpecifiers.Argument {
+extension String.FormatSpecifiers.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -335,7 +335,7 @@ private extension String.FormatSpecifiers.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.FormatSpecifiers.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "Default Value"
     /// ```
     internal struct Localizable {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -140,7 +140,7 @@ private extension String.Localizable {
     }
 }
 
-private extension String.Localizable.Argument {
+extension String.Localizable.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -172,7 +172,7 @@ private extension String.Localizable.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.Localizable.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -68,7 +65,6 @@ extension String.Localizable {
             key: "Key",
             arguments: [],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -83,7 +79,6 @@ extension String.Localizable {
             key: "myDeviceVariant",
             arguments: [],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -100,7 +95,6 @@ extension String.Localizable {
                 .int(arg1)
             ],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -118,7 +112,6 @@ extension String.Localizable {
                 .int(arg2)
             ],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -265,7 +258,6 @@ extension LocalizedStringResource {
             localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
-            locale: localizable.locale,
             bundle: .from(description: localizable.bundle)
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "Options:\n- One\n- Two\n- Three"
     /// ```
     internal struct Multiline {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -98,7 +98,7 @@ private extension String.Multiline {
     }
 }
 
-private extension String.Multiline.Argument {
+extension String.Multiline.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -130,7 +130,7 @@ private extension String.Multiline.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.Multiline.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -73,7 +70,6 @@ extension String.Multiline {
             key: "multiline",
             arguments: [],
             table: "Multiline",
-            locale: .current,
             bundle: .current
         )
     }
@@ -198,7 +194,6 @@ extension LocalizedStringResource {
             multiline.key,
             defaultValue: multiline.defaultValue,
             table: multiline.table,
-            locale: multiline.locale,
             bundle: .from(description: multiline.bundle)
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "bar"
     /// ```
     internal struct Positional {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -132,7 +132,7 @@ private extension String.Positional {
     }
 }
 
-private extension String.Positional.Argument {
+extension String.Positional.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -164,7 +164,7 @@ private extension String.Positional.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.Positional.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -71,7 +68,6 @@ extension String.Positional {
                 .object(arg2)
             ],
             table: "Positional",
-            locale: .current,
             bundle: .current
         )
     }
@@ -90,7 +86,6 @@ extension String.Positional {
                 .int(arg1)
             ],
             table: "Positional",
-            locale: .current,
             bundle: .current
         )
     }
@@ -109,7 +104,6 @@ extension String.Positional {
                 .object(arg1)
             ],
             table: "Positional",
-            locale: .current,
             bundle: .current
         )
     }
@@ -251,7 +245,6 @@ extension LocalizedStringResource {
             positional.key,
             defaultValue: positional.defaultValue,
             table: positional.table,
-            locale: positional.locale,
             bundle: .from(description: positional.bundle)
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "My Value"
     /// ```
     internal struct Simple {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -93,7 +93,7 @@ private extension String.Simple {
     }
 }
 
-private extension String.Simple.Argument {
+extension String.Simple.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -125,7 +125,7 @@ private extension String.Simple.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.Simple.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -68,7 +65,6 @@ extension String.Simple {
             key: "SimpleKey",
             arguments: [],
             table: "Simple",
-            locale: .current,
             bundle: .current
         )
     }
@@ -188,7 +184,6 @@ extension LocalizedStringResource {
             simple.key,
             defaultValue: simple.defaultValue,
             table: simple.table,
-            locale: simple.locale,
             bundle: .from(description: simple.bundle)
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "bar"
     /// ```
     internal struct Substitution {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -97,7 +97,7 @@ private extension String.Substitution {
     }
 }
 
-private extension String.Substitution.Argument {
+extension String.Substitution.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -129,7 +129,7 @@ private extension String.Substitution.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.Substitution.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -72,7 +69,6 @@ extension String.Substitution {
                 .int(arg3)
             ],
             table: "Substitution",
-            locale: .current,
             bundle: .current
         )
     }
@@ -192,7 +188,6 @@ extension LocalizedStringResource {
             substitution.key,
             defaultValue: substitution.defaultValue,
             table: substitution.table,
-            locale: substitution.locale,
             bundle: .from(description: substitution.bundle)
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -68,7 +65,6 @@ extension String.Variations {
             key: "String.Device",
             arguments: [],
             table: "Variations",
-            locale: .current,
             bundle: .current
         )
     }
@@ -85,7 +81,6 @@ extension String.Variations {
                 .int(arg1)
             ],
             table: "Variations",
-            locale: .current,
             bundle: .current
         )
     }
@@ -214,7 +209,6 @@ extension LocalizedStringResource {
             variations.key,
             defaultValue: variations.defaultValue,
             table: variations.table,
-            locale: variations.locale,
             bundle: .from(description: variations.bundle)
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "Tap to open"
     /// ```
     internal struct Variations {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -109,7 +109,7 @@ private extension String.Variations {
     }
 }
 
-private extension String.Variations.Argument {
+extension String.Variations.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -141,7 +141,7 @@ private extension String.Variations.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.Variations.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "Default Value"
     /// ```
     package struct Localizable {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -140,7 +140,7 @@ private extension String.Localizable {
     }
 }
 
-private extension String.Localizable.Argument {
+extension String.Localizable.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -172,7 +172,7 @@ private extension String.Localizable.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.Localizable.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -68,7 +65,6 @@ extension String.Localizable {
             key: "Key",
             arguments: [],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -83,7 +79,6 @@ extension String.Localizable {
             key: "myDeviceVariant",
             arguments: [],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -100,7 +95,6 @@ extension String.Localizable {
                 .int(arg1)
             ],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -118,7 +112,6 @@ extension String.Localizable {
                 .int(arg2)
             ],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -265,7 +258,6 @@ extension LocalizedStringResource {
             localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
-            locale: localizable.locale,
             bundle: .from(description: localizable.bundle)
         )
     }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -9,13 +9,13 @@ extension String {
     /// value // "Default Value"
     /// ```
     public struct Localizable {
-        fileprivate enum BundleDescription {
+        enum BundleDescription {
             case main
             case atURL(URL)
             case forClass(AnyClass)
         }
 
-        fileprivate enum Argument {
+        enum Argument {
             case object(String)
             case int(Int)
             case uint(UInt)
@@ -23,10 +23,10 @@ extension String {
             case float(Float)
         }
 
-        fileprivate let key: StaticString
-        fileprivate let arguments: [Argument]
-        fileprivate let table: String?
-        fileprivate let bundle: BundleDescription
+        let key: StaticString
+        let arguments: [Argument]
+        let table: String?
+        let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
@@ -140,7 +140,7 @@ private extension String.Localizable {
     }
 }
 
-private extension String.Localizable.Argument {
+extension String.Localizable.Argument {
     var value: CVarArg {
         switch self {
         case .int(let value):
@@ -172,7 +172,7 @@ private extension String.Localizable.BundleDescription {
     }
 }
 
-private extension Bundle {
+extension Bundle {
     static func from(description: String.Localizable.BundleDescription) -> Bundle? {
         switch description {
         case .main:

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -26,20 +26,17 @@ extension String {
         fileprivate let key: StaticString
         fileprivate let arguments: [Argument]
         fileprivate let table: String?
-        fileprivate let locale: Locale
         fileprivate let bundle: BundleDescription
 
         fileprivate init(
             key: StaticString,
             arguments: [Argument],
             table: String?,
-            locale: Locale,
             bundle: BundleDescription
         ) {
             self.key = key
             self.arguments = arguments
             self.table = table
-            self.locale = locale
             self.bundle = bundle
         }
     }
@@ -68,7 +65,6 @@ extension String.Localizable {
             key: "Key",
             arguments: [],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -83,7 +79,6 @@ extension String.Localizable {
             key: "myDeviceVariant",
             arguments: [],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -100,7 +95,6 @@ extension String.Localizable {
                 .int(arg1)
             ],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -118,7 +112,6 @@ extension String.Localizable {
                 .int(arg2)
             ],
             table: "Localizable",
-            locale: .current,
             bundle: .current
         )
     }
@@ -265,7 +258,6 @@ extension LocalizedStringResource {
             localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
-            locale: localizable.locale,
             bundle: .from(description: localizable.bundle)
         )
     }


### PR DESCRIPTION
In 0.2.0, we moved away from generating `LocalizedStringResource` directly by instead generating a `String.{TableName}` struct. 

This struct was then available for use in a generated `String.init({tableName}:)` initialiser, as well as being used as the backbone of the generated `LocalizedStringResource` accessors. 

Up until now, the internals of the generated type have remained private. This was the case because I didn't anticipate a scenario where you would need to know the key/table/bundle since the initalizers are there for you. However since I learned that the pre-ios 16 apis for resolving strings do not let you change the language, this changes a bit...

In this PR, I've updated the generated code so that the internal properties of the generated type are all `internal`. This would in theory allow you to write your own resolution method that can change the language etc. It's niche, but useful.