### PR TITLE
Refactor generated code to use less extensions 

### DIFF
--- a/Sources/StringGenerator/Extensions/SourceFileSyntax.swift
+++ b/Sources/StringGenerator/Extensions/SourceFileSyntax.swift
@@ -15,4 +15,3 @@ extension SourceFileSyntax {
         return copy
     }
 }
-

--- a/Sources/StringGenerator/Extensions/SyntaxCollection.swift
+++ b/Sources/StringGenerator/Extensions/SyntaxCollection.swift
@@ -1,0 +1,9 @@
+import SwiftSyntax
+
+extension SyntaxCollection {
+    public func map(
+        _ transform: (Element) throws -> Element
+    ) rethrows -> Self {
+        Self(try map(transform) as [Element])
+    }
+}

--- a/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct_ResourceAccessor.swift
+++ b/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct_ResourceAccessor.swift
@@ -14,8 +14,8 @@ extension SourceFile.StringExtension.StringsTableStruct {
             .identifier(resource.identifier)
         }
 
-        var type: some TypeSyntaxProtocol {
-            IdentifierTypeSyntax(name: .keyword(.Self))
+        var type: TokenSyntax {
+            sourceFile.stringExtension.stringsTableStruct.type
         }
 
         var headerDocumentation: String {

--- a/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
@@ -22,21 +22,6 @@ struct SourceFileSnippet: Snippet {
                 }
             }
 
-            ExtensionSnippet(
-                accessLevel: .private,
-                extending: sourceFile.stringExtension.stringsTableStruct.bundleDescriptionEnum.fullyQualifiedType
-            ) {
-                IfConfigDeclSyntax(
-                    prefixOperator: "!",
-                    reference: "SWIFT_PACKAGE",
-                    elements: .decls(MemberBlockItemListSyntax {
-                        StringStringsTableBundleLocatorClassSnippet()
-                    })
-                )
-
-                StringStringsTableBundleDescriptionCurrentComputedPropertySnippet()
-            }
-
             ExtensionSnippet(extending: .type(.Bundle)) {
                 ConvertBundleDescriptionMethodSnippet.toFoundationBundle(
                     from: sourceFile.stringExtension.stringsTableStruct.bundleDescriptionEnum

--- a/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
@@ -12,16 +12,6 @@ struct SourceFileSnippet: Snippet {
                 StringInitializerSnippet(stringsTable: sourceFile.stringExtension.stringsTableStruct)
             }
 
-            ExtensionSnippet(extending: sourceFile.stringExtension.stringsTableStruct.fullyQualifiedType) {
-                for accessor in sourceFile.stringExtension.stringsTableStruct.accessors {
-                    if accessor.hasArguments {
-                        StringStringsTableResourceFunctionSnippet(accessor: accessor)
-                    } else {
-                        StringStringsTableResourceVariableSnippet(accessor: accessor)
-                    }
-                }
-            }
-
             ExtensionSnippet(extending: .type(.Bundle)) {
                 ConvertBundleDescriptionMethodSnippet.toFoundationBundle(
                     from: sourceFile.stringExtension.stringsTableStruct.bundleDescriptionEnum

--- a/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
@@ -23,16 +23,6 @@ struct SourceFileSnippet: Snippet {
             }
 
             ExtensionSnippet(
-                availability: .wwdc2021,
-                accessLevel: .private,
-                extending: sourceFile.stringExtension.stringsTableStruct.fullyQualifiedType
-            ) {
-                StringStringsTableDefaultValueComputedPropertySnippet(
-                    stringsTable: sourceFile.stringExtension.stringsTableStruct
-                )
-            }
-
-            ExtensionSnippet(
                 accessLevel: .private,
                 extending: sourceFile.stringExtension.stringsTableStruct.bundleDescriptionEnum.fullyQualifiedType
             ) {

--- a/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
@@ -33,14 +33,6 @@ struct SourceFileSnippet: Snippet {
             }
 
             ExtensionSnippet(
-                extending: sourceFile.stringExtension.stringsTableStruct.argumentEnum.fullyQualifiedType
-            ) {
-                StringStringsTableArgumentValueComputedProperty(
-                    argumentEnum: sourceFile.stringExtension.stringsTableStruct.argumentEnum
-                )
-            }
-
-            ExtensionSnippet(
                 accessLevel: .private,
                 extending: sourceFile.stringExtension.stringsTableStruct.bundleDescriptionEnum.fullyQualifiedType
             ) {

--- a/Sources/StringGenerator/Snippets/String/StringsTable/Argument/StringStringsTableArgumentEnumSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/Argument/StringStringsTableArgumentEnumSnippet.swift
@@ -6,9 +6,16 @@ struct StringStringsTableArgumentEnumSnippet: Snippet {
 
     var syntax: some DeclSyntaxProtocol {
         EnumDeclSyntax(name: argument.type) {
-            for enumCase in argument.cases {
-                Case(enumCase: enumCase)
+            MemberBlockItemListSyntax {
+                for enumCase in argument.cases {
+                    Case(enumCase: enumCase)
+                }
             }
+            .with(\.trailingTrivia, .newlines(2))
+
+            StringStringsTableArgumentValueComputedProperty(
+                argumentEnum: argument
+            )
         }
     }
 }

--- a/Sources/StringGenerator/Snippets/String/StringsTable/BundleDescription/StringStringsTableBundleDescriptionCurrentComputedPropertySnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/BundleDescription/StringStringsTableBundleDescriptionCurrentComputedPropertySnippet.swift
@@ -11,7 +11,7 @@ struct StringStringsTableBundleDescriptionCurrentComputedPropertySnippet: Snippe
             bindings: [
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(identifier: "current"),
-                    typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: "Self")),
+                    typeAnnotation: TypeAnnotationSyntax(type: .identifier(.BundleDescription)),
                     accessorBlock: AccessorBlockSyntax(
                         accessors: .getter([
                             CodeBlockItemSyntax(

--- a/Sources/StringGenerator/Snippets/String/StringsTable/BundleDescription/StringStringsTableBundleDescriptionEnumSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/BundleDescription/StringStringsTableBundleDescriptionEnumSnippet.swift
@@ -15,9 +15,23 @@ struct StringStringsTableBundleDescriptionEnumSnippet: Snippet {
 
     var syntax: some DeclSyntaxProtocol {
         EnumDeclSyntax(name: bundleDescription.type) {
-            for enumCase in bundleDescription.cases {
-                Case(enumCase: enumCase)
+            MemberBlockItemListSyntax {
+                for enumCase in bundleDescription.cases {
+                    Case(enumCase: enumCase)
+                }
             }
+            .with(\.trailingTrivia, .newlines(2))
+
+            IfConfigDeclSyntax(
+                prefixOperator: "!",
+                reference: "SWIFT_PACKAGE",
+                elements: .decls(MemberBlockItemListSyntax {
+                    StringStringsTableBundleLocatorClassSnippet()
+                })
+            )
+            .with(\.trailingTrivia, .newlines(2))
+
+            StringStringsTableBundleDescriptionCurrentComputedPropertySnippet()
         }
     }
 }

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableDefaultValueComputedPropertySnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableDefaultValueComputedPropertySnippet.swift
@@ -5,14 +5,30 @@ struct StringStringsTableDefaultValueComputedPropertySnippet: Snippet {
     let stringsTable: SourceFile.StringExtension.StringsTableStruct
 
     var syntax: some DeclSyntaxProtocol {
-        // var defaultValue: String.LocalizationValue { ... }
-        VariableDeclSyntax(bindingSpecifier: .keyword(.var)) {
+        // @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        // fileprivate var defaultValue: String.LocalizationValue { ... }
+        VariableDeclSyntax(
+            attributes: attributes,
+            modifiers: modifiers,
+            bindingSpecifier: .keyword(.var)
+        ) {
             PatternBindingSyntax(
                 pattern: IdentifierPatternSyntax(identifier: .identifier("defaultValue")),
                 typeAnnotation: typeAnnotation,
                 accessorBlock: AccessorBlockSyntax(accessors: .getter(body))
             )
         }
+    }
+
+    @AttributeListBuilder
+    var attributes: AttributeListSyntax {
+        AttributeSyntax(availability: .wwdc2021)
+            .with(\.trailingTrivia, .newline)
+    }
+
+    @DeclModifierListBuilder
+    var modifiers: DeclModifierListSyntax {
+        DeclModifierSyntax(name: .keyword(.fileprivate))
     }
 
     var typeAnnotation: TypeAnnotationSyntax {

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableResourceFunctionSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableResourceFunctionSnippet.swift
@@ -15,7 +15,7 @@ struct StringStringsTableResourceFunctionSnippet: Snippet {
                         FunctionParameterSyntax(argument: argument)
                     }
                 }.commaSeparated(),
-                returnClause: ReturnClauseSyntax(type: accessor.type)
+                returnClause: ReturnClauseSyntax(type: IdentifierTypeSyntax(name: accessor.type))
             ),
             body: CodeBlockSyntax(statements: body)
         )
@@ -34,9 +34,7 @@ struct StringStringsTableResourceFunctionSnippet: Snippet {
     @CodeBlockItemListBuilder
     var body: CodeBlockItemListSyntax {
         FunctionCallExprSyntax(
-            callee: DeclReferenceExprSyntax(
-                baseName: .keyword(.Self)
-            )
+            callee: DeclReferenceExprSyntax(baseName: accessor.type)
         ) {
             LabeledExprSyntax(
                 label: "key",

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableResourceVariableSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableResourceVariableSnippet.swift
@@ -12,7 +12,7 @@ struct StringStringsTableResourceVariableSnippet: Snippet {
             bindings: [
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(identifier: accessor.name),
-                    typeAnnotation: TypeAnnotationSyntax(type: accessor.type),
+                    typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: accessor.type)),
                     accessorBlock: AccessorBlockSyntax(
                         accessors: .getter(getter)
                     )
@@ -34,9 +34,7 @@ struct StringStringsTableResourceVariableSnippet: Snippet {
     @CodeBlockItemListBuilder
     var getter: CodeBlockItemListSyntax {
         FunctionCallExprSyntax(
-            callee: DeclReferenceExprSyntax(
-                baseName: .keyword(.Self)
-            )
+            callee: DeclReferenceExprSyntax(baseName: accessor.type)
         ) {
             LabeledExprSyntax(
                 label: "key",

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
@@ -61,6 +61,17 @@ struct StringStringsTableStructSnippet: Snippet {
             }
             .with(\.trailingTrivia, .newlines(2))
 
+            MemberBlockItemListSyntax {
+                for accessor in stringsTable.accessors {
+                    if accessor.hasArguments {
+                        StringStringsTableResourceFunctionSnippet(accessor: accessor)
+                    } else {
+                        StringStringsTableResourceVariableSnippet(accessor: accessor)
+                    }
+                }
+            }
+            .map { $0.with(\.trailingTrivia, .newlines(2)) }
+
             // @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
             // fileprivate var defaultValue: String.LocalizedValue { ... }
             StringStringsTableDefaultValueComputedPropertySnippet(

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
@@ -59,6 +59,13 @@ struct StringStringsTableStructSnippet: Snippet {
                     )
                 }
             }
+            .with(\.trailingTrivia, .newlines(2))
+
+            // @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+            // fileprivate var defaultValue: String.LocalizedValue { ... }
+            StringStringsTableDefaultValueComputedPropertySnippet(
+                stringsTable: stringsTable
+            )
         }
     }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     internal init(formatSpecifiers: FormatSpecifiers, locale: Locale? = nil) {
@@ -292,29 +313,6 @@ extension String.FormatSpecifiers {
             table: "FormatSpecifiers",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.FormatSpecifiers {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -68,6 +68,232 @@ extension String {
             self.bundle = bundle
         }
 
+        /// %@ should convert to a String argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %@
+        /// ```
+        internal static func at(_ arg1: String) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "at",
+                arguments: [
+                    .object(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %d should convert to an Int argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %d
+        /// ```
+        internal static func d(_ arg1: Int) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "d",
+                arguments: [
+                    .int(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %lld should covert to an Int
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %lld
+        /// ```
+        internal static func d_length(_ arg1: Int) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "d_length",
+                arguments: [
+                    .int(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %f should convert to a Double argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %f
+        /// ```
+        internal static func f(_ arg1: Double) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "f",
+                arguments: [
+                    .double(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %.2f should convert to a Double argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %.2f
+        /// ```
+        internal static func f_precision(_ arg1: Double) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "f_precision",
+                arguments: [
+                    .double(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %i should convert to an Int argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %i
+        /// ```
+        internal static func i(_ arg1: Int) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "i",
+                arguments: [
+                    .int(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %o should convert to a UInt argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %o
+        /// ```
+        internal static func o(_ arg1: UInt) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "o",
+                arguments: [
+                    .uint(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// % should not be converted to an argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %
+        /// ```
+        internal static var percentage: FormatSpecifiers {
+            FormatSpecifiers(
+                key: "percentage",
+                arguments: [],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %% should not be converted to an argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %%
+        /// ```
+        internal static var percentage_escaped: FormatSpecifiers {
+            FormatSpecifiers(
+                key: "percentage_escaped",
+                arguments: [],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %% should not be converted to an argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test 50%% off
+        /// ```
+        internal static var percentage_escaped_space_o: FormatSpecifiers {
+            FormatSpecifiers(
+                key: "percentage_escaped_space_o",
+                arguments: [],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// '% o' should not be converted to an argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test 50% off
+        /// ```
+        internal static var percentage_space_o: FormatSpecifiers {
+            FormatSpecifiers(
+                key: "percentage_space_o",
+                arguments: [],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %u should convert to a UInt argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %u
+        /// ```
+        internal static func u(_ arg1: UInt) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "u",
+                arguments: [
+                    .uint(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
+        /// %x should convert to a UInt argument
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Test %x
+        /// ```
+        internal static func x(_ arg1: UInt) -> FormatSpecifiers {
+            FormatSpecifiers(
+                key: "x",
+                arguments: [
+                    .uint(arg1)
+                ],
+                table: "FormatSpecifiers",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,234 +323,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: formatSpecifiers.table),
             locale: locale,
             arguments: formatSpecifiers.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.FormatSpecifiers {
-    /// %@ should convert to a String argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %@
-    /// ```
-    internal static func at(_ arg1: String) -> Self {
-        Self (
-            key: "at",
-            arguments: [
-                .object(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %d should convert to an Int argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %d
-    /// ```
-    internal static func d(_ arg1: Int) -> Self {
-        Self (
-            key: "d",
-            arguments: [
-                .int(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %lld should covert to an Int
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %lld
-    /// ```
-    internal static func d_length(_ arg1: Int) -> Self {
-        Self (
-            key: "d_length",
-            arguments: [
-                .int(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %f should convert to a Double argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %f
-    /// ```
-    internal static func f(_ arg1: Double) -> Self {
-        Self (
-            key: "f",
-            arguments: [
-                .double(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %.2f should convert to a Double argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %.2f
-    /// ```
-    internal static func f_precision(_ arg1: Double) -> Self {
-        Self (
-            key: "f_precision",
-            arguments: [
-                .double(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %i should convert to an Int argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %i
-    /// ```
-    internal static func i(_ arg1: Int) -> Self {
-        Self (
-            key: "i",
-            arguments: [
-                .int(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %o should convert to a UInt argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %o
-    /// ```
-    internal static func o(_ arg1: UInt) -> Self {
-        Self (
-            key: "o",
-            arguments: [
-                .uint(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// % should not be converted to an argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %
-    /// ```
-    internal static var percentage: Self {
-        Self (
-            key: "percentage",
-            arguments: [],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %% should not be converted to an argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %%
-    /// ```
-    internal static var percentage_escaped: Self {
-        Self (
-            key: "percentage_escaped",
-            arguments: [],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %% should not be converted to an argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test 50%% off
-    /// ```
-    internal static var percentage_escaped_space_o: Self {
-        Self (
-            key: "percentage_escaped_space_o",
-            arguments: [],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// '% o' should not be converted to an argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test 50% off
-    /// ```
-    internal static var percentage_space_o: Self {
-        Self (
-            key: "percentage_space_o",
-            arguments: [],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %u should convert to a UInt argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %u
-    /// ```
-    internal static func u(_ arg1: UInt) -> Self {
-        Self (
-            key: "u",
-            arguments: [
-                .uint(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
-        )
-    }
-
-    /// %x should convert to a UInt argument
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Test %x
-    /// ```
-    internal static func x(_ arg1: UInt) -> Self {
-        Self (
-            key: "x",
-            arguments: [
-                .uint(arg1)
-            ],
-            table: "FormatSpecifiers",
-            bundle: .current
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -300,23 +315,6 @@ private extension String.FormatSpecifiers {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.FormatSpecifiers.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -313,21 +326,6 @@ extension String.FormatSpecifiers {
             table: "FormatSpecifiers",
             bundle: .current
         )
-    }
-}
-
-private extension String.FormatSpecifiers.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -68,6 +68,69 @@ extension String {
             self.bundle = bundle
         }
 
+        /// This is a comment
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Default Value
+        /// ```
+        internal static var key: Localizable {
+            Localizable(
+                key: "Key",
+                arguments: [],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Multiplatform Original
+        /// ```
+        internal static var myDeviceVariant: Localizable {
+            Localizable(
+                key: "myDeviceVariant",
+                arguments: [],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// I have %lld plurals
+        /// ```
+        internal static func myPlural(_ arg1: Int) -> Localizable {
+            Localizable(
+                key: "myPlural",
+                arguments: [
+                    .int(arg1)
+                ],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %lld: People liked %lld posts
+        /// ```
+        internal static func mySubstitute(_ arg1: Int, count arg2: Int) -> Localizable {
+            Localizable(
+                key: "mySubstitute",
+                arguments: [
+                    .int(arg1),
+                    .int(arg2)
+                ],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,71 +160,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: localizable.table),
             locale: locale,
             arguments: localizable.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.Localizable {
-    /// This is a comment
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Default Value
-    /// ```
-    internal static var key: Self {
-        Self (
-            key: "Key",
-            arguments: [],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Multiplatform Original
-    /// ```
-    internal static var myDeviceVariant: Self {
-        Self (
-            key: "myDeviceVariant",
-            arguments: [],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// I have %lld plurals
-    /// ```
-    internal static func myPlural(_ arg1: Int) -> Self {
-        Self (
-            key: "myPlural",
-            arguments: [
-                .int(arg1)
-            ],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// %lld: People liked %lld posts
-    /// ```
-    internal static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
-        Self (
-            key: "mySubstitute",
-            arguments: [
-                .int(arg1),
-                .int(arg2)
-            ],
-            table: "Localizable",
-            bundle: .current
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -137,23 +152,6 @@ private extension String.Localizable {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.Localizable.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     internal init(localizable: Localizable, locale: Locale? = nil) {
@@ -129,29 +150,6 @@ extension String.Localizable {
             table: "Localizable",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.Localizable {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -150,21 +163,6 @@ extension String.Localizable {
             table: "Localizable",
             bundle: .current
         )
-    }
-}
-
-private extension String.Localizable.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     internal init(multiline: Multiline, locale: Locale? = nil) {
@@ -87,29 +108,6 @@ extension String.Multiline {
             table: "Multiline",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.Multiline {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -108,21 +121,6 @@ extension String.Multiline {
             table: "Multiline",
             bundle: .current
         )
-    }
-}
-
-private extension String.Multiline.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -68,6 +68,27 @@ extension String {
             self.bundle = bundle
         }
 
+        /// This example tests the following:
+        /// 1. That line breaks in the defaultValue are supported
+        /// 2. That line breaks in the comment are supported
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Options:
+        /// - One
+        /// - Two
+        /// - Three
+        /// ```
+        internal static var multiline: Multiline {
+            Multiline(
+                key: "multiline",
+                arguments: [],
+                table: "Multiline",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,29 +118,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: multiline.table),
             locale: locale,
             arguments: multiline.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.Multiline {
-    /// This example tests the following:
-    /// 1. That line breaks in the defaultValue are supported
-    /// 2. That line breaks in the comment are supported
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Options:
-    /// - One
-    /// - Two
-    /// - Three
-    /// ```
-    internal static var multiline: Self {
-        Self (
-            key: "multiline",
-            arguments: [],
-            table: "Multiline",
-            bundle: .current
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -95,23 +110,6 @@ private extension String.Multiline {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.Multiline.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     internal init(positional: Positional, locale: Locale? = nil) {
@@ -121,29 +142,6 @@ extension String.Positional {
             table: "Positional",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.Positional {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -129,23 +144,6 @@ private extension String.Positional {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.Positional.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -142,21 +155,6 @@ extension String.Positional {
             table: "Positional",
             bundle: .current
         )
-    }
-}
-
-private extension String.Positional.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -68,6 +68,61 @@ extension String {
             self.bundle = bundle
         }
 
+        /// A string where the second argument is at the front of the string and the first argument is at the end
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Second: %2$@ - First: %1$lld
+        /// ```
+        internal static func reorder(_ arg1: Int, _ arg2: String) -> Positional {
+            Positional(
+                key: "reorder",
+                arguments: [
+                    .int(arg1),
+                    .object(arg2)
+                ],
+                table: "Positional",
+                bundle: .current
+            )
+        }
+
+        /// A string that uses the same argument twice
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %1$lld, I repeat: %1$lld
+        /// ```
+        internal static func repeatExplicit(_ arg1: Int) -> Positional {
+            Positional(
+                key: "repeatExplicit",
+                arguments: [
+                    .int(arg1)
+                ],
+                table: "Positional",
+                bundle: .current
+            )
+        }
+
+        /// A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %@, are you there? %1$@?
+        /// ```
+        internal static func repeatImplicit(_ arg1: String) -> Positional {
+            Positional(
+                key: "repeatImplicit",
+                arguments: [
+                    .object(arg1)
+                ],
+                table: "Positional",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,63 +152,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: positional.table),
             locale: locale,
             arguments: positional.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.Positional {
-    /// A string where the second argument is at the front of the string and the first argument is at the end
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Second: %2$@ - First: %1$lld
-    /// ```
-    internal static func reorder(_ arg1: Int, _ arg2: String) -> Self {
-        Self (
-            key: "reorder",
-            arguments: [
-                .int(arg1),
-                .object(arg2)
-            ],
-            table: "Positional",
-            bundle: .current
-        )
-    }
-
-    /// A string that uses the same argument twice
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// %1$lld, I repeat: %1$lld
-    /// ```
-    internal static func repeatExplicit(_ arg1: Int) -> Self {
-        Self (
-            key: "repeatExplicit",
-            arguments: [
-                .int(arg1)
-            ],
-            table: "Positional",
-            bundle: .current
-        )
-    }
-
-    /// A string that uses the same argument twice implicitly because a positional specifier wasn't provided in one instance
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// %@, are you there? %1$@?
-    /// ```
-    internal static func repeatImplicit(_ arg1: String) -> Self {
-        Self (
-            key: "repeatImplicit",
-            arguments: [
-                .object(arg1)
-            ],
-            table: "Positional",
-            bundle: .current
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     internal init(simple: Simple, locale: Locale? = nil) {
@@ -82,29 +103,6 @@ extension String.Simple {
             table: "Simple",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.Simple {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -90,23 +105,6 @@ private extension String.Simple {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.Simple.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -103,21 +116,6 @@ extension String.Simple {
             table: "Simple",
             bundle: .current
         )
-    }
-}
-
-private extension String.Simple.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -68,6 +68,22 @@ extension String {
             self.bundle = bundle
         }
 
+        /// This is a simple key and value
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// My Value
+        /// ```
+        internal static var simpleKey: Simple {
+            Simple(
+                key: "SimpleKey",
+                arguments: [],
+                table: "Simple",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,24 +113,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: simple.table),
             locale: locale,
             arguments: simple.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.Simple {
-    /// This is a simple key and value
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// My Value
-    /// ```
-    internal static var simpleKey: Self {
-        Self (
-            key: "SimpleKey",
-            arguments: [],
-            table: "Simple",
-            bundle: .current
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -107,21 +120,6 @@ extension String.Substitution {
             table: "Substitution",
             bundle: .current
         )
-    }
-}
-
-private extension String.Substitution.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -68,6 +68,26 @@ extension String {
             self.bundle = bundle
         }
 
+        /// A string that uses substitutions as well as arguments
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %@! There are %lld strings and you have %lld remaining
+        /// ```
+        internal static func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> Substitution {
+            Substitution(
+                key: "substitutions_example.string",
+                arguments: [
+                    .object(arg1),
+                    .int(arg2),
+                    .int(arg3)
+                ],
+                table: "Substitution",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,28 +117,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: substitution.table),
             locale: locale,
             arguments: substitution.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.Substitution {
-    /// A string that uses substitutions as well as arguments
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// %@! There are %lld strings and you have %lld remaining
-    /// ```
-    internal static func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> Self {
-        Self (
-            key: "substitutions_example.string",
-            arguments: [
-                .object(arg1),
-                .int(arg2),
-                .int(arg3)
-            ],
-            table: "Substitution",
-            bundle: .current
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     internal init(substitution: Substitution, locale: Locale? = nil) {
@@ -86,29 +107,6 @@ extension String.Substitution {
             table: "Substitution",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.Substitution {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -94,23 +109,6 @@ private extension String.Substitution {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.Substitution.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -68,6 +68,38 @@ extension String {
             self.bundle = bundle
         }
 
+        /// A string that should have a macOS variation to replace 'Tap' with 'Click'
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Tap to open
+        /// ```
+        internal static var stringDevice: Variations {
+            Variations(
+                key: "String.Device",
+                arguments: [],
+                table: "Variations",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// I have %lld strings
+        /// ```
+        internal static func stringPlural(_ arg1: Int) -> Variations {
+            Variations(
+                key: "String.Plural",
+                arguments: [
+                    .int(arg1)
+                ],
+                table: "Variations",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,40 +129,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: variations.table),
             locale: locale,
             arguments: variations.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.Variations {
-    /// A string that should have a macOS variation to replace 'Tap' with 'Click'
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Tap to open
-    /// ```
-    internal static var stringDevice: Self {
-        Self (
-            key: "String.Device",
-            arguments: [],
-            table: "Variations",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// I have %lld strings
-    /// ```
-    internal static func stringPlural(_ arg1: Int) -> Self {
-        Self (
-            key: "String.Plural",
-            arguments: [
-                .int(arg1)
-            ],
-            table: "Variations",
-            bundle: .current
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     internal init(variations: Variations, locale: Locale? = nil) {
@@ -98,29 +119,6 @@ extension String.Variations {
             table: "Variations",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.Variations {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -106,23 +121,6 @@ private extension String.Variations {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.Variations.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -119,21 +132,6 @@ extension String.Variations {
             table: "Variations",
             bundle: .current
         )
-    }
-}
-
-private extension String.Variations.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -68,6 +68,69 @@ extension String {
             self.bundle = bundle
         }
 
+        /// This is a comment
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Default Value
+        /// ```
+        package static var key: Localizable {
+            Localizable(
+                key: "Key",
+                arguments: [],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Multiplatform Original
+        /// ```
+        package static var myDeviceVariant: Localizable {
+            Localizable(
+                key: "myDeviceVariant",
+                arguments: [],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// I have %lld plurals
+        /// ```
+        package static func myPlural(_ arg1: Int) -> Localizable {
+            Localizable(
+                key: "myPlural",
+                arguments: [
+                    .int(arg1)
+                ],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %lld: People liked %lld posts
+        /// ```
+        package static func mySubstitute(_ arg1: Int, count arg2: Int) -> Localizable {
+            Localizable(
+                key: "mySubstitute",
+                arguments: [
+                    .int(arg1),
+                    .int(arg2)
+                ],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,71 +160,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: localizable.table),
             locale: locale,
             arguments: localizable.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.Localizable {
-    /// This is a comment
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Default Value
-    /// ```
-    package static var key: Self {
-        Self (
-            key: "Key",
-            arguments: [],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Multiplatform Original
-    /// ```
-    package static var myDeviceVariant: Self {
-        Self (
-            key: "myDeviceVariant",
-            arguments: [],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// I have %lld plurals
-    /// ```
-    package static func myPlural(_ arg1: Int) -> Self {
-        Self (
-            key: "myPlural",
-            arguments: [
-                .int(arg1)
-            ],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// %lld: People liked %lld posts
-    /// ```
-    package static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
-        Self (
-            key: "mySubstitute",
-            arguments: [
-                .int(arg1),
-                .int(arg2)
-            ],
-            table: "Localizable",
-            bundle: .current
         )
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -137,23 +152,6 @@ private extension String.Localizable {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.Localizable.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     package init(localizable: Localizable, locale: Locale? = nil) {
@@ -129,29 +150,6 @@ extension String.Localizable {
             table: "Localizable",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.Localizable {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -150,21 +163,6 @@ extension String.Localizable {
             table: "Localizable",
             bundle: .current
         )
-    }
-}
-
-private extension String.Localizable.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -21,6 +21,21 @@ extension String {
             case float(Float)
             case double(Double)
             case object(String)
+
+            var value: CVarArg {
+                switch self {
+                case .int(let value):
+                    value
+                case .uint(let value):
+                    value
+                case .float(let value):
+                    value
+                case .double(let value):
+                    value
+                case .object(let value):
+                    value
+                }
+            }
         }
 
         let key: StaticString
@@ -137,23 +152,6 @@ private extension String.Localizable {
         }
         let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
         return makeDefaultValue(stringInterpolation)
-    }
-}
-
-extension String.Localizable.Argument {
-    var value: CVarArg {
-        switch self {
-        case .int(let value):
-            value
-        case .uint(let value):
-            value
-        case .float(let value):
-            value
-        case .double(let value):
-            value
-        case .object(let value):
-            value
-        }
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -13,6 +13,19 @@ extension String {
             case main
             case atURL(URL)
             case forClass(AnyClass)
+
+            #if !SWIFT_PACKAGE
+            private class BundleLocator {
+            }
+            #endif
+
+            static var current: BundleDescription {
+                #if SWIFT_PACKAGE
+                .atURL(Bundle.module.bundleURL)
+                #else
+                .forClass(BundleLocator.self)
+                #endif
+            }
         }
 
         enum Argument {
@@ -150,21 +163,6 @@ extension String.Localizable {
             table: "Localizable",
             bundle: .current
         )
-    }
-}
-
-private extension String.Localizable.BundleDescription {
-    #if !SWIFT_PACKAGE
-    private class BundleLocator {
-    }
-    #endif
-
-    static var current: Self {
-        #if SWIFT_PACKAGE
-        .atURL(Bundle.module.bundleURL)
-        #else
-        .forClass(BundleLocator.self)
-        #endif
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -54,6 +54,27 @@ extension String {
             self.table = table
             self.bundle = bundle
         }
+
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        fileprivate var defaultValue: String.LocalizationValue {
+            var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
+            for argument in arguments {
+                switch argument {
+                case .int(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .uint(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .float(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .double(let value):
+                    stringInterpolation.appendInterpolation(value)
+                case .object(let value):
+                    stringInterpolation.appendInterpolation(value)
+                }
+            }
+            let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
+            return makeDefaultValue(stringInterpolation)
+        }
     }
 
     public init(localizable: Localizable, locale: Locale? = nil) {
@@ -129,29 +150,6 @@ extension String.Localizable {
             table: "Localizable",
             bundle: .current
         )
-    }
-}
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-private extension String.Localizable {
-    var defaultValue: String.LocalizationValue {
-        var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
-        for argument in arguments {
-            switch argument {
-            case .int(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .uint(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .float(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .double(let value):
-                stringInterpolation.appendInterpolation(value)
-            case .object(let value):
-                stringInterpolation.appendInterpolation(value)
-            }
-        }
-        let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-        return makeDefaultValue(stringInterpolation)
     }
 }
 

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -68,6 +68,69 @@ extension String {
             self.bundle = bundle
         }
 
+        /// This is a comment
+        ///
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Default Value
+        /// ```
+        public static var key: Localizable {
+            Localizable(
+                key: "Key",
+                arguments: [],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// Multiplatform Original
+        /// ```
+        public static var myDeviceVariant: Localizable {
+            Localizable(
+                key: "myDeviceVariant",
+                arguments: [],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// I have %lld plurals
+        /// ```
+        public static func myPlural(_ arg1: Int) -> Localizable {
+            Localizable(
+                key: "myPlural",
+                arguments: [
+                    .int(arg1)
+                ],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
+        /// ### Source Localization
+        ///
+        /// ```
+        /// %lld: People liked %lld posts
+        /// ```
+        public static func mySubstitute(_ arg1: Int, count arg2: Int) -> Localizable {
+            Localizable(
+                key: "mySubstitute",
+                arguments: [
+                    .int(arg1),
+                    .int(arg2)
+                ],
+                table: "Localizable",
+                bundle: .current
+            )
+        }
+
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         fileprivate var defaultValue: String.LocalizationValue {
             var stringInterpolation = String.LocalizationValue.StringInterpolation(literalCapacity: 0, interpolationCount: arguments.count)
@@ -97,71 +160,6 @@ extension String {
             format: bundle.localizedString(forKey: key, value: nil, table: localizable.table),
             locale: locale,
             arguments: localizable.arguments.map(\.value)
-        )
-    }
-}
-
-extension String.Localizable {
-    /// This is a comment
-    ///
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Default Value
-    /// ```
-    public static var key: Self {
-        Self (
-            key: "Key",
-            arguments: [],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// Multiplatform Original
-    /// ```
-    public static var myDeviceVariant: Self {
-        Self (
-            key: "myDeviceVariant",
-            arguments: [],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// I have %lld plurals
-    /// ```
-    public static func myPlural(_ arg1: Int) -> Self {
-        Self (
-            key: "myPlural",
-            arguments: [
-                .int(arg1)
-            ],
-            table: "Localizable",
-            bundle: .current
-        )
-    }
-
-    /// ### Source Localization
-    ///
-    /// ```
-    /// %lld: People liked %lld posts
-    /// ```
-    public static func mySubstitute(_ arg1: Int, count arg2: Int) -> Self {
-        Self (
-            key: "mySubstitute",
-            arguments: [
-                .int(arg1),
-                .int(arg2)
-            ],
-            table: "Localizable",
-            bundle: .current
         )
     }
 }


### PR DESCRIPTION
The original generated code was split across many extensions. While nice, it was a bit hard to maintain. It makes more sense to just bring things into the main declarations.