### PR TITLE
Change declaration and make `LocalizedStringResource.init(localizable:)` internal

### DIFF
--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/LocalizedStringResourceInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/LocalizedStringResourceInitializerSnippet.swift
@@ -12,7 +12,6 @@ struct LocalizedStringResourceInitializerSnippet {
 extension LocalizedStringResourceInitializerSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
         InitializerDeclSyntax(
-            modifiers: modifiers,
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax(
                     leftParen: .leftParenToken(),
@@ -59,10 +58,5 @@ extension LocalizedStringResourceInitializerSnippet: Snippet {
             }
             .multiline()
         }
-    }
-    
-    @DeclModifierListBuilder
-    var modifiers: DeclModifierListSyntax {
-        DeclModifierSyntax(name: .keyword(.private))
     }
 }

--- a/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
@@ -36,12 +36,12 @@ struct SourceFileSnippet: Snippet {
                     stringsTable: sourceFile.localizedStringResourceExtension.stringsTableStruct
                 )
 
-                LocalizedStringResourceInitializerSnippet(
-                    stringsTable: sourceFile.stringExtension.stringsTableStruct
-                )
-
                 LocalizedStringResourceStringsTableComputedPropertySnippet(
                     sourceFile: sourceFile
+                )
+
+                LocalizedStringResourceInitializerSnippet(
+                    stringsTable: sourceFile.stringExtension.stringsTableStruct
                 )
             }
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -513,7 +513,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(formatSpecifiers: String.FormatSpecifiers) {
+    internal static let formatSpecifiers = FormatSpecifiers()
+
+    init(formatSpecifiers: String.FormatSpecifiers) {
         self.init(
             formatSpecifiers.key,
             defaultValue: formatSpecifiers.defaultValue,
@@ -521,6 +523,4 @@ extension LocalizedStringResource {
             bundle: .from(description: formatSpecifiers.bundle)
         )
     }
-
-    internal static let formatSpecifiers = FormatSpecifiers()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -245,7 +245,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(localizable: String.Localizable) {
+    internal static let localizable = Localizable()
+
+    init(localizable: String.Localizable) {
         self.init(
             localizable.key,
             defaultValue: localizable.defaultValue,
@@ -253,6 +255,4 @@ extension LocalizedStringResource {
             bundle: .from(description: localizable.bundle)
         )
     }
-
-    internal static let localizable = Localizable()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -181,7 +181,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(multiline: String.Multiline) {
+    internal static let multiline = Multiline()
+
+    init(multiline: String.Multiline) {
         self.init(
             multiline.key,
             defaultValue: multiline.defaultValue,
@@ -189,6 +191,4 @@ extension LocalizedStringResource {
             bundle: .from(description: multiline.bundle)
         )
     }
-
-    internal static let multiline = Multiline()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -232,7 +232,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(positional: String.Positional) {
+    internal static let positional = Positional()
+
+    init(positional: String.Positional) {
         self.init(
             positional.key,
             defaultValue: positional.defaultValue,
@@ -240,6 +242,4 @@ extension LocalizedStringResource {
             bundle: .from(description: positional.bundle)
         )
     }
-
-    internal static let positional = Positional()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -171,7 +171,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(simple: String.Simple) {
+    internal static let simple = Simple()
+
+    init(simple: String.Simple) {
         self.init(
             simple.key,
             defaultValue: simple.defaultValue,
@@ -179,6 +181,4 @@ extension LocalizedStringResource {
             bundle: .from(description: simple.bundle)
         )
     }
-
-    internal static let simple = Simple()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -175,7 +175,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(substitution: String.Substitution) {
+    internal static let substitution = Substitution()
+
+    init(substitution: String.Substitution) {
         self.init(
             substitution.key,
             defaultValue: substitution.defaultValue,
@@ -183,6 +185,4 @@ extension LocalizedStringResource {
             bundle: .from(description: substitution.bundle)
         )
     }
-
-    internal static let substitution = Substitution()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -196,7 +196,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(variations: String.Variations) {
+    internal static let variations = Variations()
+
+    init(variations: String.Variations) {
         self.init(
             variations.key,
             defaultValue: variations.defaultValue,
@@ -204,6 +206,4 @@ extension LocalizedStringResource {
             bundle: .from(description: variations.bundle)
         )
     }
-
-    internal static let variations = Variations()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -245,7 +245,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(localizable: String.Localizable) {
+    package static let localizable = Localizable()
+
+    init(localizable: String.Localizable) {
         self.init(
             localizable.key,
             defaultValue: localizable.defaultValue,
@@ -253,6 +255,4 @@ extension LocalizedStringResource {
             bundle: .from(description: localizable.bundle)
         )
     }
-
-    package static let localizable = Localizable()
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -245,7 +245,9 @@ extension LocalizedStringResource {
         }
     }
 
-    private init(localizable: String.Localizable) {
+    public static let localizable = Localizable()
+
+    init(localizable: String.Localizable) {
         self.init(
             localizable.key,
             defaultValue: localizable.defaultValue,
@@ -253,6 +255,4 @@ extension LocalizedStringResource {
             bundle: .from(description: localizable.bundle)
         )
     }
-
-    public static let localizable = Localizable()
 }


### PR DESCRIPTION
`LocalizedStringResource.init(localizable:)` use to be `private`, but since we will add a similar initialiser for `Text` as part of #60, it maybe makes sense to expose this a bit more. 

Also because I plan to deprecate the duplicate accessors on `LocalizedStringResource`