### PR TITLE
Add backwards compatible initialisers for `Text` and `LocalizedStringsKey`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -114,6 +114,10 @@ let package = Package(
             dependencies: [
                 .target(name: "XCStringsToolPlugin")
             ],
+            resources: [
+                .process("FeatureOne.xcstrings"),
+                .process("Localizable.xcstrings")
+            ],
             swiftSettings: [
                 .define("XCSTRINGS_TOOL_ACCESS_LEVEL_PUBLIC")
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,8 @@ let package = Package(
                 .target(name: "StringExtractor"),
                 .target(name: "StringGenerator"),
                 .target(name: "StringResource"),
-                .target(name: "StringValidator")
+                .target(name: "StringValidator"),
+                .target(name: "Version")
             ]
         ),
 
@@ -57,7 +58,8 @@ let package = Package(
                 .target(name: "SwiftIdentifier"),
                 .product(name: "SwiftBasicFormat", package: "swift-syntax"),
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax")
+                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+                .target(name: "Version")
             ]
         ),
 
@@ -71,6 +73,10 @@ let package = Package(
 
         .target(
             name: "SwiftIdentifier"
+        ),
+
+        .target(
+            name: "Version"
         ),
 
         .target(

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ struct ContentView: View {
                     ItemView(item)
                 }
             } footer: {
-                Text(.localizable.footerText(items.count))
+                Text(.localizable(.footerText(items.count)))
             }
         }
-        .navigationTitle(Text(.localizable.contentViewTitle))
+        .navigationTitle(.localizable(.contentViewTitle))
     }
 }
 ```

--- a/Sources/StringGenerator/Extensions/IfExprSyntax.swift
+++ b/Sources/StringGenerator/Extensions/IfExprSyntax.swift
@@ -1,0 +1,41 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension IfExprSyntax {
+    init(
+        availability: AvailabilityArgumentListSyntax,
+        body: CodeBlockSyntax,
+        elseBody: CodeBlockSyntax? = nil
+    ) {
+        self.init(
+            conditions: ConditionElementListSyntax {
+                AvailabilityConditionSyntax(availabilityKeyword: .poundAvailableToken(), availabilityArguments: availability)
+            },
+            body: body,
+            elseKeyword: elseBody.flatMap { _ in .keyword(.else) },
+            elseBody: elseBody.flatMap { .codeBlock($0) }
+        )
+    }
+
+    init(
+        availability: AvailabilityArgumentListSyntax,
+        @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax
+    ) {
+        self.init(
+            availability: availability,
+            body: CodeBlockSyntax(statements: bodyBuilder())
+        )
+    }
+
+    init(
+        availability: AvailabilityArgumentListSyntax,
+        @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax,
+        @CodeBlockItemListBuilder elseBodyBuilder: () -> CodeBlockItemListSyntax
+    ) {
+        self.init(
+            availability: availability,
+            body: CodeBlockSyntax(statements: bodyBuilder()),
+            elseBody: CodeBlockSyntax(statements: elseBodyBuilder())
+        )
+    }
+}

--- a/Sources/StringGenerator/Extensions/TokenSyntax+Types.swift
+++ b/Sources/StringGenerator/Extensions/TokenSyntax+Types.swift
@@ -20,6 +20,7 @@ extension TokenSyntax {
         case Argument
         case CVarArg
         case LocalizedStringKey
+        case Text
     }
 
     static func type(_ value: MetaType) -> TokenSyntax {

--- a/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
+++ b/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
@@ -1,5 +1,6 @@
 import StringResource
 import SwiftSyntax
+import Version
 
 extension SourceFile.StringExtension {
     struct StringsTableStruct {
@@ -111,7 +112,7 @@ extension SourceFile.StringExtension {
         }
         ```
 
-        - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+        - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/\(version)/documentation/documentation/using-the-generated-source-code)
         """
         }
     }

--- a/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
+++ b/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
@@ -66,13 +66,52 @@ extension SourceFile.StringExtension {
 
         var headerDocumentation: String {
         """
-        Constant values for the \(sourceFile.tableName) Strings Catalog
+        A type that represents localized strings from the ‘\(sourceFile.tableName)‘
+        strings table.
+
+        Do not initialize instances of this type yourself, instead use one of the static
+        methods or properties that have been generated automatically.
+
+        ## Usage
+
+        ### Foundation
+
+        In Foundation, you can resolve the localized string using the system language
+        with the `String`.``Swift/String/init(\(sourceFile.tableVariableIdentifier):locale:)``
+        intializer:
 
         ```swift
         // Accessing the localized value directly
         let value = String(\(sourceFile.tableVariableIdentifier): .\(example.name))
         value // \"\(example.value)\"
         ```
+
+        Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+        be used:
+
+        ```swift
+        var resource = LocalizedStringResource(\(sourceFile.tableVariableIdentifier): .\(example.name))
+        resource.locale = Locale(identifier: "fr") // customise language
+        let value = String(localized: resource)    // defer lookup
+        ```
+
+        ### SwiftUI
+
+        In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(\(sourceFile.tableVariableIdentifier):)``
+        or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/\(sourceFile.tableVariableIdentifier)(_:)``
+        in order for localized values to be resolved within the SwiftUI environment:
+
+        ```swift
+        var body: some View {
+            List {
+                Text(\(sourceFile.tableVariableIdentifier): .listContent)
+            }
+            .navigationTitle(.\(sourceFile.tableVariableIdentifier)(.navigationTitle))
+            .environment(\\.locale, Locale(identifier: "fr"))
+        }
+        ```
+
+        - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
         """
         }
     }

--- a/Sources/StringGenerator/Snippets/IfCanImportSnippet.swift
+++ b/Sources/StringGenerator/Snippets/IfCanImportSnippet.swift
@@ -1,0 +1,30 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+struct IfCanImportSnippet {
+    let module: TokenSyntax.Module
+    let items: CodeBlockItemListSyntax
+}
+
+extension IfCanImportSnippet {
+    init(
+        module: TokenSyntax.Module,
+        @CodeBlockItemListBuilder itemsBuilder: () -> CodeBlockItemListSyntax
+    ) {
+        self.init(module: module, items: itemsBuilder())
+    }
+}
+
+extension IfCanImportSnippet: Snippet {
+    var syntax: some DeclSyntaxProtocol {
+        IfConfigDeclSyntax(
+            clauses: IfConfigClauseListSyntax {
+                IfConfigClauseSyntax(
+                    poundKeyword: .poundIfToken(),
+                    condition: CanImportExprSyntax(importPath: .module(module)),
+                    elements: .statements(items)
+                )
+            }
+        )
+    }
+}

--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/LocalizedStringResourceInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/LocalizedStringResourceInitializerSnippet.swift
@@ -12,6 +12,7 @@ struct LocalizedStringResourceInitializerSnippet {
 extension LocalizedStringResourceInitializerSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
         InitializerDeclSyntax(
+            modifiers: modifiers,
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax(
                     leftParen: .leftParenToken(),
@@ -58,5 +59,10 @@ extension LocalizedStringResourceInitializerSnippet: Snippet {
             }
             .multiline()
         }
+    }
+
+    @DeclModifierListBuilder
+    var modifiers: DeclModifierListSyntax {
+        DeclModifierSyntax(name: stringsTable.accessLevel.token)
     }
 }

--- a/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
@@ -43,6 +43,11 @@ struct SourceFileSnippet: Snippet {
                 LocalizedStringResourceInitializerSnippet(
                     stringsTable: sourceFile.stringExtension.stringsTableStruct
                 )
+
+                StringsTableConversionStaticMethodSnippet(
+                    stringsTable: sourceFile.stringExtension.stringsTableStruct,
+                    returnType: .type(.LocalizedStringResource)
+                )
             }
 
             IfCanImportSnippet(module: .SwiftUI) {
@@ -68,6 +73,12 @@ struct SourceFileSnippet: Snippet {
                     LocalizedStringKeyInitializerSnippet(
                         stringsTable: sourceFile.stringExtension.stringsTableStruct
                     )
+
+                    StringsTableConversionStaticMethodSnippet(
+                        stringsTable: sourceFile.stringExtension.stringsTableStruct,
+                        returnType: .type(.LocalizedStringKey)
+                    )
+
                     LocalizedStringKeyOverrideKeySnippet()
                 }
             }

--- a/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
@@ -44,8 +44,31 @@ struct SourceFileSnippet: Snippet {
                     stringsTable: sourceFile.stringExtension.stringsTableStruct
                 )
             }
+
+            IfCanImportSnippet(module: .SwiftUI) {
+                ImportSnippet(module: .SwiftUI)
+                    .syntax
+                    .with(\.trailingTrivia, .newlines(2))
+
+                ExtensionSnippet(
+                    availability: .wwdc2019,
+                    extending: .type(.Text)
+                ) {
+                    TextInitializerSnippet(
+                        stringsTable: sourceFile.stringExtension.stringsTableStruct
+                    )
+                }
+                .syntax
+                .with(\.trailingTrivia, .newlines(2))
+
+                ExtensionSnippet(
+                    availability: .wwdc2019,
+                    extending: .type(.LocalizedStringKey)
+                ) {
+                    LocalizedStringKeyOverrideKeySnippet()
+                }
+            }
         }
         .spacingStatements()
-        .with(\.trailingTrivia, .newline)
     }
 }

--- a/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SourceFileSnippet.swift
@@ -65,6 +65,9 @@ struct SourceFileSnippet: Snippet {
                     availability: .wwdc2019,
                     extending: .type(.LocalizedStringKey)
                 ) {
+                    LocalizedStringKeyInitializerSnippet(
+                        stringsTable: sourceFile.stringExtension.stringsTableStruct
+                    )
                     LocalizedStringKeyOverrideKeySnippet()
                 }
             }

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
@@ -11,8 +11,17 @@ struct StringStringsTableStructSnippet: Snippet {
         StructDeclSyntax(
             leadingTrivia: leadingTrivia,
             modifiers: modifiers,
-            name: stringsTable.type
-        ) {
+            name: stringsTable.type,
+            memberBlock: memberBlock
+        )
+    }
+
+    var leadingTrivia: Trivia? {
+        Trivia(docComment: stringsTable.headerDocumentation)
+    }
+
+    var memberBlock: MemberBlockSyntax {
+        MemberBlockSyntax {
             // enum BundleDescription { ... }
             StringStringsTableBundleDescriptionEnumSnippet(bundleDescription: stringsTable.bundleDescriptionEnum)
                 .syntax
@@ -78,10 +87,6 @@ struct StringStringsTableStructSnippet: Snippet {
                 stringsTable: stringsTable
             )
         }
-    }
-
-    var leadingTrivia: Trivia? {
-        Trivia(docComment: stringsTable.headerDocumentation)
     }
 
     @DeclModifierListBuilder

--- a/Sources/StringGenerator/Snippets/StringInterpolation/AppendFormatSpecifiableInterpolationsSnippet.swift
+++ b/Sources/StringGenerator/Snippets/StringInterpolation/AppendFormatSpecifiableInterpolationsSnippet.swift
@@ -1,17 +1,31 @@
 import StringResource
 import SwiftSyntax
 
-struct AppendFormatSpecifiableInterpolationsSnippet {
+struct AppendFormatSpecifiableInterpolationsSnippet<Sequence: ExprSyntaxProtocol> {
     let argumentsEnum: SourceFile.StringExtension.StringsTableStruct.ArgumentEnum
-    let sequenceName: TokenSyntax
+    let sequence: Sequence
     let variableName: TokenSyntax
+}
+
+extension AppendFormatSpecifiableInterpolationsSnippet where Sequence == DeclReferenceExprSyntax {
+    init(
+        argumentsEnum: SourceFile.StringExtension.StringsTableStruct.ArgumentEnum,
+        sequenceName: TokenSyntax,
+        variableName: TokenSyntax
+    ) {
+        self.init(
+            argumentsEnum: argumentsEnum,
+            sequence: DeclReferenceExprSyntax(baseName: sequenceName),
+            variableName: variableName
+        )
+    }
 }
 
 extension AppendFormatSpecifiableInterpolationsSnippet: Snippet {
     var syntax: some StmtSyntaxProtocol {
         ForStmtSyntax(
             pattern: IdentifierPatternSyntax(identifier: "argument"),
-            sequence: DeclReferenceExprSyntax(baseName: sequenceName),
+            sequence: sequence,
             body: CodeBlockSyntax {
                 // switch argument { ... }
                 SwitchExprSyntax(subject: DeclReferenceExprSyntax(baseName: "argument")) {

--- a/Sources/StringGenerator/Snippets/StringInterpolation/ExpressibleByStringInterplationInitializerClosureSnippet.swift
+++ b/Sources/StringGenerator/Snippets/StringInterpolation/ExpressibleByStringInterplationInitializerClosureSnippet.swift
@@ -1,9 +1,9 @@
 import SwiftSyntax
 
-struct ExpressibleByStringInterplationInitializerClosureSnippet {
+struct ExpressibleByStringInterplationInitializerClosureSnippet<T: ExprSyntaxProtocol> {
     var bindingSpecifier: Keyword = .let
     let variableName: TokenSyntax
-    let type: MemberAccessExprSyntax
+    let type: T
 }
 
 extension ExpressibleByStringInterplationInitializerClosureSnippet: Snippet {

--- a/Sources/StringGenerator/Snippets/StringsTableConversionStaticMethodSnippet.swift
+++ b/Sources/StringGenerator/Snippets/StringsTableConversionStaticMethodSnippet.swift
@@ -9,11 +9,18 @@ struct StringsTableConversionStaticMethodSnippet {
 extension StringsTableConversionStaticMethodSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
         FunctionDeclSyntax(
+            leadingTrivia: leadingTrivia,
             modifiers: modifiers,
             name: name,
             signature: signature,
             body: body
         )
+    }
+
+    var leadingTrivia: Trivia? {
+        Trivia(docComment: """
+        Creates a `\(returnType.text)` that represents a localized value in the ‘\(stringsTable.sourceFile.tableName)‘ strings table.
+        """)
     }
 
     @DeclModifierListBuilder

--- a/Sources/StringGenerator/Snippets/StringsTableConversionStaticMethodSnippet.swift
+++ b/Sources/StringGenerator/Snippets/StringsTableConversionStaticMethodSnippet.swift
@@ -1,0 +1,54 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+struct StringsTableConversionStaticMethodSnippet {
+    let stringsTable: SourceFile.StringExtension.StringsTableStruct
+    let returnType: TokenSyntax
+}
+
+extension StringsTableConversionStaticMethodSnippet: Snippet {
+    var syntax: some DeclSyntaxProtocol {
+        FunctionDeclSyntax(
+            modifiers: modifiers,
+            name: name,
+            signature: signature,
+            body: body
+        )
+    }
+
+    @DeclModifierListBuilder
+    var modifiers: DeclModifierListSyntax {
+        DeclModifierSyntax(name: stringsTable.accessLevel.token)
+        DeclModifierSyntax(name: .keyword(.static))
+    }
+
+    var name: TokenSyntax {
+        .identifier(stringsTable.sourceFile.tableVariableIdentifier)
+    }
+
+    var signature: FunctionSignatureSyntax {
+        FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax {
+                FunctionParameterSyntax(
+                    firstName: .wildcardToken(),
+                    secondName: name,
+                    type: MemberTypeSyntax(tokens: stringsTable.fullyQualifiedType)
+                )
+            },
+            returnClause: ReturnClauseSyntax(
+                type: IdentifierTypeSyntax(name: returnType)
+            )
+        )
+    }
+
+    var body: CodeBlockSyntax {
+        CodeBlockSyntax {
+            FunctionCallExprSyntax(callee: DeclReferenceExprSyntax(baseName: returnType)) {
+                LabeledExprSyntax(
+                    label: name.text,
+                    expression: DeclReferenceExprSyntax(baseName: name)
+                )
+            }
+        }
+    }
+}

--- a/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyInitializerSnippet.swift
@@ -11,7 +11,41 @@ struct LocalizedStringKeyInitializerSnippet {
 
 extension LocalizedStringKeyInitializerSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
-        InitializerDeclSyntax(modifiers: modifiers, signature: signature) {
+        InitializerDeclSyntax(
+            leadingTrivia: leadingTrivia,
+            modifiers: modifiers,
+            signature: signature,
+            body: body
+        )
+    }
+
+    var leadingTrivia: Trivia? {
+        Trivia(docComment: """
+        Creates a localized string key that represents a localized value in the ‘\(stringsTable.sourceFile.tableName)‘ strings table.
+        """)
+    }
+
+    @DeclModifierListBuilder
+    var modifiers: DeclModifierListSyntax {
+        DeclModifierSyntax(name: stringsTable.accessLevel.token)
+    }
+
+    var signature: FunctionSignatureSyntax {
+        FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax(
+                leftParen: .leftParenToken(),
+                rightParen: .rightParenToken()
+            ) {
+                FunctionParameterSyntax(
+                    firstName: variableToken,
+                    type: typeSyntax(from: stringsTable.fullyQualifiedType)
+                )
+            }
+        )
+    }
+
+    var body: CodeBlockSyntax {
+        CodeBlockSyntax {
             // let text = Text(localizable: localizable)
             VariableDeclSyntax(
                 .let,
@@ -65,25 +99,6 @@ extension LocalizedStringKeyInitializerSnippet: Snippet {
                 }
             )
         }
-    }
-
-    @DeclModifierListBuilder
-    var modifiers: DeclModifierListSyntax {
-        DeclModifierSyntax(name: stringsTable.accessLevel.token)
-    }
-
-    var signature: FunctionSignatureSyntax {
-        FunctionSignatureSyntax(
-            parameterClause: FunctionParameterClauseSyntax(
-                leftParen: .leftParenToken(),
-                rightParen: .rightParenToken()
-            ) {
-                FunctionParameterSyntax(
-                    firstName: variableToken,
-                    type: typeSyntax(from: stringsTable.fullyQualifiedType)
-                )
-            }
-        )
     }
 
     var ifAvailableUseLocalizedStringResource: some ExprSyntaxProtocol {

--- a/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyInitializerSnippet.swift
@@ -1,0 +1,147 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+struct LocalizedStringKeyInitializerSnippet {
+    let stringsTable: SourceFile.StringExtension.StringsTableStruct
+
+    var variableToken: TokenSyntax {
+        .identifier(stringsTable.sourceFile.tableVariableIdentifier)
+    }
+}
+
+extension LocalizedStringKeyInitializerSnippet: Snippet {
+    var syntax: some DeclSyntaxProtocol {
+        InitializerDeclSyntax(signature: signature) {
+            // let text = Text(localizable: localizable)
+            VariableDeclSyntax(
+                .let,
+                name: PatternSyntax(IdentifierPatternSyntax(identifier: "text")),
+                initializer: InitializerClauseSyntax(
+                    value: FunctionCallExprSyntax(
+                        callee: DeclReferenceExprSyntax(baseName: .type(.Text))
+                    ) {
+                        LabeledExprSyntax(
+                            label: variableToken.text,
+                            expression: DeclReferenceExprSyntax(baseName: variableToken)
+                        )
+                    }
+                )
+            )
+            .with(\.trailingTrivia, .newlines(2))
+
+            // var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+            // stringInterpolation.appendInterpolation(text)
+            StringInterpolationVariableInitializerSnippet(
+                variableName: "stringInterpolation",
+                type: MemberAccessExprSyntax(.type(.LocalizedStringKey), .type(.StringInterpolation)),
+                literalCapacity: IntegerLiteralExprSyntax(0),
+                interpolationCount: IntegerLiteralExprSyntax(1)
+            )
+            FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: "stringInterpolation"),
+                    name: "appendInterpolation"
+                )
+            ) {
+                LabeledExprSyntax(
+                    expression: DeclReferenceExprSyntax(baseName: "text")
+                )
+            }
+            .with(\.trailingTrivia, .newlines(2))
+
+            // let makeKey = LocalizedStringKey.init(stringInterpolation:)
+            // self = makeKey(stringInterpolation)
+            ExpressibleByStringInterplationInitializerClosureSnippet(
+                variableName: "makeKey",
+                type: DeclReferenceExprSyntax(baseName: .type(.LocalizedStringKey))
+            )
+            InfixOperatorExprSyntax(
+                leftOperand: DeclReferenceExprSyntax(baseName: .keyword(.`self`)),
+                operator: AssignmentExprSyntax(),
+                rightOperand: FunctionCallExprSyntax(
+                    callee: DeclReferenceExprSyntax(baseName: "makeKey")
+                ) {
+                    LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: "stringInterpolation"))
+                }
+            )
+        }
+    }
+
+    var signature: FunctionSignatureSyntax {
+        FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax(
+                leftParen: .leftParenToken(),
+                rightParen: .rightParenToken()
+            ) {
+                FunctionParameterSyntax(
+                    firstName: variableToken,
+                    type: typeSyntax(from: stringsTable.fullyQualifiedType)
+                )
+            }
+        )
+    }
+
+    var ifAvailableUseLocalizedStringResource: some ExprSyntaxProtocol {
+        IfExprSyntax(
+            conditions: ConditionElementListSyntax {
+                AvailabilityConditionSyntax(
+                    availabilityKeyword: .poundAvailableToken(),
+                    availabilityArguments: .wwdc2022
+                )
+            },
+            body: CodeBlockSyntax(statements: CodeBlockItemListSyntax {
+                // self.init(LocalizedStringResource(localizable: localizable))
+                FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax("self", "init")
+                ) {
+                    // LocalizedStringResource(localizable: localizable)
+                    LabeledExprSyntax(
+                        expression: FunctionCallExprSyntax(
+                            callee: DeclReferenceExprSyntax(baseName: .type(.LocalizedStringResource))
+                        ) {
+                            LabeledExprSyntax(
+                                label: variableToken.text,
+                                expression: DeclReferenceExprSyntax(baseName: variableToken)
+                            )
+                        }
+                    )
+                }
+
+                // return
+                ReturnStmtSyntax()
+            })
+        )
+    }
+
+    var initWithKeyTableAndBundle: some ExprSyntaxProtocol {
+        // self.init(key, table: localizable.table, bundle: .from(description: localizable.bundle)
+        FunctionCallExprSyntax(
+            callee: MemberAccessExprSyntax("self", "init")
+        ) {
+            // key,
+            LabeledExprSyntax(
+                expression: DeclReferenceExprSyntax(baseName: "key")
+            )
+
+            // tableName: localizable.table,
+            LabeledExprSyntax(
+                label: "tableName",
+                expression: MemberAccessExprSyntax(variableToken, stringsTable.tableProperty.name)
+            )
+
+            // bundle: .from(description: localizable.bundle)
+            LabeledExprSyntax(
+                label: "bundle",
+                expression: FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(name: "from")
+                ) {
+                    // description: localizable.bundle
+                    LabeledExprSyntax(
+                        label: "description",
+                        expression: MemberAccessExprSyntax(variableToken, stringsTable.bundleProperty.name)
+                    )
+                }
+            )
+        }
+    }
+}

--- a/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyInitializerSnippet.swift
@@ -11,7 +11,7 @@ struct LocalizedStringKeyInitializerSnippet {
 
 extension LocalizedStringKeyInitializerSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
-        InitializerDeclSyntax(signature: signature) {
+        InitializerDeclSyntax(modifiers: modifiers, signature: signature) {
             // let text = Text(localizable: localizable)
             VariableDeclSyntax(
                 .let,
@@ -65,6 +65,11 @@ extension LocalizedStringKeyInitializerSnippet: Snippet {
                 }
             )
         }
+    }
+
+    @DeclModifierListBuilder
+    var modifiers: DeclModifierListSyntax {
+        DeclModifierSyntax(name: stringsTable.accessLevel.token)
     }
 
     var signature: FunctionSignatureSyntax {

--- a/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyOverrideKeySnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyOverrideKeySnippet.swift
@@ -4,6 +4,14 @@ import SwiftSyntaxBuilder
 struct LocalizedStringKeyOverrideKeySnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
         DeclSyntax("""
+        /// Updates the underlying `key` used when performing localization lookups.
+        ///
+        /// By default, an instance of `LocalizedStringKey` can only be created
+        /// using string interpolation, so if arguments are included, the format
+        /// specifiers make up part of the key.
+        ///
+        /// This method allows you to change the key after initialization in order
+        /// to match the value that might be defined in the strings table.
         fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
             withUnsafeMutablePointer(to: &self) { pointer in
                 let raw = UnsafeMutableRawPointer(pointer)

--- a/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyOverrideKeySnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyOverrideKeySnippet.swift
@@ -1,0 +1,16 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+struct LocalizedStringKeyOverrideKeySnippet: Snippet {
+    var syntax: some DeclSyntaxProtocol {
+        DeclSyntax("""
+        fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
+            withUnsafeMutablePointer(to: &self) { pointer in
+                let raw = UnsafeMutableRawPointer(pointer)
+                let bound = raw.assumingMemoryBound(to: String.self)
+                bound.pointee = String(describing: key)
+            }
+        }
+        """)
+    }
+}

--- a/Sources/StringGenerator/Snippets/SwiftUI/TextInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/TextInitializerSnippet.swift
@@ -102,35 +102,27 @@ extension TextInitializerSnippet: Snippet {
     }
 
     var ifAvailableUseLocalizedStringResource: some ExprSyntaxProtocol {
-        IfExprSyntax(
-            conditions: ConditionElementListSyntax {
-                AvailabilityConditionSyntax(
-                    availabilityKeyword: .poundAvailableToken(),
-                    availabilityArguments: .wwdc2022
+        IfExprSyntax(availability: .wwdc2022) {
+            // self.init(LocalizedStringResource(localizable: localizable))
+            FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax("self", "init")
+            ) {
+                // LocalizedStringResource(localizable: localizable)
+                LabeledExprSyntax(
+                    expression: FunctionCallExprSyntax(
+                        callee: DeclReferenceExprSyntax(baseName: .type(.LocalizedStringResource))
+                    ) {
+                        LabeledExprSyntax(
+                            label: variableToken.text,
+                            expression: DeclReferenceExprSyntax(baseName: variableToken)
+                        )
+                    }
                 )
-            },
-            body: CodeBlockSyntax(statements: CodeBlockItemListSyntax {
-                // self.init(LocalizedStringResource(localizable: localizable))
-                FunctionCallExprSyntax(
-                    callee: MemberAccessExprSyntax("self", "init")
-                ) {
-                    // LocalizedStringResource(localizable: localizable)
-                    LabeledExprSyntax(
-                        expression: FunctionCallExprSyntax(
-                            callee: DeclReferenceExprSyntax(baseName: .type(.LocalizedStringResource))
-                        ) {
-                            LabeledExprSyntax(
-                                label: variableToken.text,
-                                expression: DeclReferenceExprSyntax(baseName: variableToken)
-                            )
-                        }
-                    )
-                }
+            }
 
-                // return
-                ReturnStmtSyntax()
-            })
-        )
+            // return
+            ReturnStmtSyntax()
+        }
     }
 
     var initWithKeyTableAndBundle: some ExprSyntaxProtocol {

--- a/Sources/StringGenerator/Snippets/SwiftUI/TextInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/TextInitializerSnippet.swift
@@ -11,7 +11,41 @@ struct TextInitializerSnippet {
 
 extension TextInitializerSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
-        InitializerDeclSyntax(signature: signature) {
+        InitializerDeclSyntax(
+            leadingTrivia: leadingTrivia,
+            modifiers: modifiers,
+            signature: signature,
+            body: body
+        )
+    }
+
+    var leadingTrivia: Trivia? {
+        Trivia(docComment: """
+        Creates a text view that displays a localized string defined in the ‘\(stringsTable.sourceFile.tableName)‘ strings table.
+        """)
+    }
+
+    @DeclModifierListBuilder
+    var modifiers: DeclModifierListSyntax {
+        DeclModifierSyntax(name: stringsTable.accessLevel.token)
+    }
+
+    var signature: FunctionSignatureSyntax {
+        FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax(
+                leftParen: .leftParenToken(),
+                rightParen: .rightParenToken()
+            ) {
+                FunctionParameterSyntax(
+                    firstName: variableToken,
+                    type: typeSyntax(from: stringsTable.fullyQualifiedType)
+                )
+            }
+        )
+    }
+
+    var body: CodeBlockSyntax {
+        CodeBlockSyntax {
             // if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) { ... }
             ifAvailableUseLocalizedStringResource
                 .with(\.trailingTrivia, .newlines(2))
@@ -65,20 +99,6 @@ extension TextInitializerSnippet: Snippet {
             // self.init(key, tableName: localizable.table, bundle: .from(description: localizable.bundle)
             initWithKeyTableAndBundle
         }
-    }
-
-    var signature: FunctionSignatureSyntax {
-        FunctionSignatureSyntax(
-            parameterClause: FunctionParameterClauseSyntax(
-                leftParen: .leftParenToken(),
-                rightParen: .rightParenToken()
-            ) {
-                FunctionParameterSyntax(
-                    firstName: variableToken,
-                    type: typeSyntax(from: stringsTable.fullyQualifiedType)
-                )
-            }
-        )
     }
 
     var ifAvailableUseLocalizedStringResource: some ExprSyntaxProtocol {

--- a/Sources/StringGenerator/Snippets/SwiftUI/TextInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/TextInitializerSnippet.swift
@@ -1,0 +1,147 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+struct TextInitializerSnippet {
+    let stringsTable: SourceFile.StringExtension.StringsTableStruct
+
+    var variableToken: TokenSyntax {
+        .identifier(stringsTable.sourceFile.tableVariableIdentifier)
+    }
+}
+
+extension TextInitializerSnippet: Snippet {
+    var syntax: some DeclSyntaxProtocol {
+        InitializerDeclSyntax(signature: signature) {
+            // if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) { ... }
+            ifAvailableUseLocalizedStringResource
+                .with(\.trailingTrivia, .newlines(2))
+
+            StringInterpolationVariableInitializerSnippet(
+                variableName: "stringInterpolation",
+                type: MemberAccessExprSyntax(.type(.LocalizedStringKey), .type(.StringInterpolation)),
+                literalCapacity: IntegerLiteralExprSyntax(0),
+                interpolationCount: MemberAccessExprSyntax(variableToken, stringsTable.argumentsProperty.name, "count")
+            )
+
+            AppendFormatSpecifiableInterpolationsSnippet(
+                argumentsEnum: stringsTable.argumentEnum,
+                sequence: MemberAccessExprSyntax(variableToken, stringsTable.argumentsProperty.name),
+                variableName: "stringInterpolation"
+            )
+
+            ExpressibleByStringInterplationInitializerClosureSnippet(
+                variableName: "makeKey",
+                type: DeclReferenceExprSyntax(baseName: .type(.LocalizedStringKey))
+            )
+            .syntax
+            .with(\.trailingTrivia, .newlines(2))
+
+            VariableDeclSyntax(
+                .var,
+                name: "key",
+                initializer: InitializerClauseSyntax(
+                    value: FunctionCallExprSyntax(
+                        callee: DeclReferenceExprSyntax(baseName: "makeKey")
+                    ) {
+                        LabeledExprSyntax(
+                            expression: DeclReferenceExprSyntax(baseName: "stringInterpolation")
+                        )
+                    }
+                )
+            )
+            FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: "key"),
+                    name: "overrideKeyForLookup"
+                )
+            ) {
+                LabeledExprSyntax(
+                    label: "using",
+                    expression: MemberAccessExprSyntax(variableToken, stringsTable.keyProperty.name)
+                )
+            }
+            .with(\.trailingTrivia, .newlines(2))
+
+            // self.init(key, tableName: localizable.table, bundle: .from(description: localizable.bundle)
+            initWithKeyTableAndBundle
+        }
+    }
+
+    var signature: FunctionSignatureSyntax {
+        FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax(
+                leftParen: .leftParenToken(),
+                rightParen: .rightParenToken()
+            ) {
+                FunctionParameterSyntax(
+                    firstName: variableToken,
+                    type: typeSyntax(from: stringsTable.fullyQualifiedType)
+                )
+            }
+        )
+    }
+
+    var ifAvailableUseLocalizedStringResource: some ExprSyntaxProtocol {
+        IfExprSyntax(
+            conditions: ConditionElementListSyntax {
+                AvailabilityConditionSyntax(
+                    availabilityKeyword: .poundAvailableToken(),
+                    availabilityArguments: .wwdc2022
+                )
+            },
+            body: CodeBlockSyntax(statements: CodeBlockItemListSyntax {
+                // self.init(LocalizedStringResource(localizable: localizable))
+                FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax("self", "init")
+                ) {
+                    // LocalizedStringResource(localizable: localizable)
+                    LabeledExprSyntax(
+                        expression: FunctionCallExprSyntax(
+                            callee: DeclReferenceExprSyntax(baseName: .type(.LocalizedStringResource))
+                        ) {
+                            LabeledExprSyntax(
+                                label: variableToken.text,
+                                expression: DeclReferenceExprSyntax(baseName: variableToken)
+                            )
+                        }
+                    )
+                }
+
+                // return
+                ReturnStmtSyntax()
+            })
+        )
+    }
+
+    var initWithKeyTableAndBundle: some ExprSyntaxProtocol {
+        // self.init(key, table: localizable.table, bundle: .from(description: localizable.bundle)
+        FunctionCallExprSyntax(
+            callee: MemberAccessExprSyntax("self", "init")
+        ) {
+            // key,
+            LabeledExprSyntax(
+                expression: DeclReferenceExprSyntax(baseName: "key")
+            )
+
+            // tableName: localizable.table,
+            LabeledExprSyntax(
+                label: "tableName",
+                expression: MemberAccessExprSyntax(variableToken, stringsTable.tableProperty.name)
+            )
+
+            // bundle: .from(description: localizable.bundle)
+            LabeledExprSyntax(
+                label: "bundle",
+                expression: FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(name: "from")
+                ) {
+                    // description: localizable.bundle
+                    LabeledExprSyntax(
+                        label: "description",
+                        expression: MemberAccessExprSyntax(variableToken, stringsTable.bundleProperty.name)
+                    )
+                }
+            )
+        }
+    }
+}

--- a/Sources/Version/Version.swift
+++ b/Sources/Version/Version.swift
@@ -1,0 +1,2 @@
+/// The version of XCStrings Tool
+public let version = "0.3.0"

--- a/Sources/xcstrings-tool/XCStringsTool.swift
+++ b/Sources/xcstrings-tool/XCStringsTool.swift
@@ -1,11 +1,12 @@
 import ArgumentParser
+import Version
 
 @main
 struct XCStringsTool: ParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "xcstrings-tool",
         abstract: "Generates Swift code from String Catalogs (.xcstrings files)",
-        version: "0.3.0",
+        version: version,
         subcommands: [Generate.self],
         defaultSubcommand: Generate.self
     )

--- a/Tests/PluginTests/PluginTests.swift
+++ b/Tests/PluginTests/PluginTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import XCTest
 
 final class PluginTests: XCTestCase {
@@ -44,5 +45,15 @@ final class PluginTests: XCTestCase {
             String(featureOne: .pluralExample(10)),
             "10 strings remaining"
         )
+    }
+
+    func testSwiftUI() {
+        var environment = EnvironmentValues()
+        environment.locale = Locale(identifier: "en")
+
+        let text = Text(featureOne: .pluralExample(3))
+        let resolved = text._resolveText(in: environment)
+
+        XCTAssertEqual(resolved, "3 strings remaining")
     }
 }

--- a/Tests/PluginTests/PluginTests.swift
+++ b/Tests/PluginTests/PluginTests.swift
@@ -51,7 +51,8 @@ final class PluginTests: XCTestCase {
         var environment = EnvironmentValues()
         environment.locale = Locale(identifier: "en")
 
-        let text = Text(featureOne: .pluralExample(3))
+        let key = LocalizedStringKey(featureOne: .pluralExample(3))
+        let text = Text(key)
         let resolved = text._resolveText(in: environment)
 
         XCTAssertEqual(resolved, "3 strings remaining")

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -609,10 +609,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘FormatSpecifiers‘ strings table.
     internal init(formatSpecifiers: String.FormatSpecifiers) {
-        let text = Text(formatSpecifiers: formatSpecifiers)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(formatSpecifiers: formatSpecifiers))
+        } else {
+            stringInterpolation.appendInterpolation(Text(formatSpecifiers: formatSpecifiers))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -562,6 +562,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(formatSpecifiers: String.FormatSpecifiers) {
+        let text = Text(formatSpecifiers: formatSpecifiers)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -515,13 +515,17 @@ extension LocalizedStringResource {
 
     internal static let formatSpecifiers = FormatSpecifiers()
 
-    init(formatSpecifiers: String.FormatSpecifiers) {
+    internal init(formatSpecifiers: String.FormatSpecifiers) {
         self.init(
             formatSpecifiers.key,
             defaultValue: formatSpecifiers.defaultValue,
             table: formatSpecifiers.table,
             bundle: .from(description: formatSpecifiers.bundle)
         )
+    }
+
+    internal static func formatSpecifiers(_ formatSpecifiers: String.FormatSpecifiers) -> LocalizedStringResource {
+        LocalizedStringResource(formatSpecifiers: formatSpecifiers)
     }
 }
 
@@ -562,7 +566,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(formatSpecifiers: String.FormatSpecifiers) {
+    internal init(formatSpecifiers: String.FormatSpecifiers) {
         let text = Text(formatSpecifiers: formatSpecifiers)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -570,6 +574,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    internal static func formatSpecifiers(_ formatSpecifiers: String.FormatSpecifiers) -> LocalizedStringKey {
+        LocalizedStringKey(formatSpecifiers: formatSpecifiers)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the FormatSpecifiers Strings Catalog
+    /// A type that represents localized strings from the ‘FormatSpecifiers‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(formatSpecifiers:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(formatSpecifiers: .percentage)
     /// value // "Test %"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(formatSpecifiers: .percentage)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(formatSpecifiers:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/formatSpecifiers(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(formatSpecifiers: .listContent)
+    ///     }
+    ///     .navigationTitle(.formatSpecifiers(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     internal struct FormatSpecifiers {
         enum BundleDescription {
             case main
@@ -524,6 +563,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘FormatSpecifiers‘ strings table.
     internal static func formatSpecifiers(_ formatSpecifiers: String.FormatSpecifiers) -> LocalizedStringResource {
         LocalizedStringResource(formatSpecifiers: formatSpecifiers)
     }
@@ -534,7 +574,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(formatSpecifiers: String.FormatSpecifiers) {
+    /// Creates a text view that displays a localized string defined in the ‘FormatSpecifiers‘ strings table.
+    internal init(formatSpecifiers: String.FormatSpecifiers) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(formatSpecifiers: formatSpecifiers))
             return
@@ -566,6 +607,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘FormatSpecifiers‘ strings table.
     internal init(formatSpecifiers: String.FormatSpecifiers) {
         let text = Text(formatSpecifiers: formatSpecifiers)
 
@@ -576,10 +618,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘FormatSpecifiers‘ strings table.
     internal static func formatSpecifiers(_ formatSpecifiers: String.FormatSpecifiers) -> LocalizedStringKey {
         LocalizedStringKey(formatSpecifiers: formatSpecifiers)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     internal struct FormatSpecifiers {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -294,6 +294,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(localizable: String.Localizable) {
+        let text = Text(localizable: localizable)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -341,10 +341,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘Localizable‘ strings table.
     internal init(localizable: String.Localizable) {
-        let text = Text(localizable: localizable)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(localizable: localizable))
+        } else {
+            stringInterpolation.appendInterpolation(Text(localizable: localizable))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -247,13 +247,17 @@ extension LocalizedStringResource {
 
     internal static let localizable = Localizable()
 
-    init(localizable: String.Localizable) {
+    internal init(localizable: String.Localizable) {
         self.init(
             localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
             bundle: .from(description: localizable.bundle)
         )
+    }
+
+    internal static func localizable(_ localizable: String.Localizable) -> LocalizedStringResource {
+        LocalizedStringResource(localizable: localizable)
     }
 }
 
@@ -294,7 +298,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(localizable: String.Localizable) {
+    internal init(localizable: String.Localizable) {
         let text = Text(localizable: localizable)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -302,6 +306,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    internal static func localizable(_ localizable: String.Localizable) -> LocalizedStringKey {
+        LocalizedStringKey(localizable: localizable)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     internal struct Localizable {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the Localizable Strings Catalog
+    /// A type that represents localized strings from the ‘Localizable‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(localizable:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(localizable: .key)
     /// value // "Default Value"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(localizable: .key)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(localizable:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/localizable(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(localizable: .listContent)
+    ///     }
+    ///     .navigationTitle(.localizable(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     internal struct Localizable {
         enum BundleDescription {
             case main
@@ -256,6 +295,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘Localizable‘ strings table.
     internal static func localizable(_ localizable: String.Localizable) -> LocalizedStringResource {
         LocalizedStringResource(localizable: localizable)
     }
@@ -266,7 +306,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(localizable: String.Localizable) {
+    /// Creates a text view that displays a localized string defined in the ‘Localizable‘ strings table.
+    internal init(localizable: String.Localizable) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(localizable: localizable))
             return
@@ -298,6 +339,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘Localizable‘ strings table.
     internal init(localizable: String.Localizable) {
         let text = Text(localizable: localizable)
 
@@ -308,10 +350,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Localizable‘ strings table.
     internal static func localizable(_ localizable: String.Localizable) -> LocalizedStringKey {
         LocalizedStringKey(localizable: localizable)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -256,3 +256,50 @@ extension LocalizedStringResource {
         )
     }
 }
+
+#if canImport (SwiftUI)
+import SwiftUI
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension Text {
+    init(localizable: String.Localizable) {
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            self.init(LocalizedStringResource(localizable: localizable))
+            return
+        }
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: localizable.arguments.count)
+        for argument in localizable.arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+
+        var key = makeKey(stringInterpolation)
+        key.overrideKeyForLookup(using: localizable.key)
+
+        self.init(key, tableName: localizable.table, bundle: .from(description: localizable.bundle))
+    }
+}
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension LocalizedStringKey {
+    fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
+        withUnsafeMutablePointer(to: &self) { pointer in
+            let raw = UnsafeMutableRawPointer(pointer)
+            let bound = raw.assumingMemoryBound(to: String.self)
+            bound.pointee = String(describing: key)
+        }
+    }
+}
+#endif

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -230,6 +230,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(multiline: String.Multiline) {
+        let text = Text(multiline: multiline)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     internal struct Multiline {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -277,10 +277,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘Multiline‘ strings table.
     internal init(multiline: String.Multiline) {
-        let text = Text(multiline: multiline)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(multiline: multiline))
+        } else {
+            stringInterpolation.appendInterpolation(Text(multiline: multiline))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the Multiline Strings Catalog
+    /// A type that represents localized strings from the ‘Multiline‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(multiline:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(multiline: .multiline)
     /// value // "Options:\n- One\n- Two\n- Three"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(multiline: .multiline)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(multiline:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/multiline(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(multiline: .listContent)
+    ///     }
+    ///     .navigationTitle(.multiline(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     internal struct Multiline {
         enum BundleDescription {
             case main
@@ -192,6 +231,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘Multiline‘ strings table.
     internal static func multiline(_ multiline: String.Multiline) -> LocalizedStringResource {
         LocalizedStringResource(multiline: multiline)
     }
@@ -202,7 +242,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(multiline: String.Multiline) {
+    /// Creates a text view that displays a localized string defined in the ‘Multiline‘ strings table.
+    internal init(multiline: String.Multiline) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(multiline: multiline))
             return
@@ -234,6 +275,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘Multiline‘ strings table.
     internal init(multiline: String.Multiline) {
         let text = Text(multiline: multiline)
 
@@ -244,10 +286,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Multiline‘ strings table.
     internal static func multiline(_ multiline: String.Multiline) -> LocalizedStringKey {
         LocalizedStringKey(multiline: multiline)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -183,13 +183,17 @@ extension LocalizedStringResource {
 
     internal static let multiline = Multiline()
 
-    init(multiline: String.Multiline) {
+    internal init(multiline: String.Multiline) {
         self.init(
             multiline.key,
             defaultValue: multiline.defaultValue,
             table: multiline.table,
             bundle: .from(description: multiline.bundle)
         )
+    }
+
+    internal static func multiline(_ multiline: String.Multiline) -> LocalizedStringResource {
+        LocalizedStringResource(multiline: multiline)
     }
 }
 
@@ -230,7 +234,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(multiline: String.Multiline) {
+    internal init(multiline: String.Multiline) {
         let text = Text(multiline: multiline)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -238,6 +242,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    internal static func multiline(_ multiline: String.Multiline) -> LocalizedStringKey {
+        LocalizedStringKey(multiline: multiline)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -243,3 +243,50 @@ extension LocalizedStringResource {
         )
     }
 }
+
+#if canImport (SwiftUI)
+import SwiftUI
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension Text {
+    init(positional: String.Positional) {
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            self.init(LocalizedStringResource(positional: positional))
+            return
+        }
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: positional.arguments.count)
+        for argument in positional.arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+
+        var key = makeKey(stringInterpolation)
+        key.overrideKeyForLookup(using: positional.key)
+
+        self.init(key, tableName: positional.table, bundle: .from(description: positional.bundle))
+    }
+}
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension LocalizedStringKey {
+    fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
+        withUnsafeMutablePointer(to: &self) { pointer in
+            let raw = UnsafeMutableRawPointer(pointer)
+            let bound = raw.assumingMemoryBound(to: String.self)
+            bound.pointee = String(describing: key)
+        }
+    }
+}
+#endif

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     internal struct Positional {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the Positional Strings Catalog
+    /// A type that represents localized strings from the ‘Positional‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(positional:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(positional: .foo)
     /// value // "bar"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(positional: .foo)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(positional:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/positional(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(positional: .listContent)
+    ///     }
+    ///     .navigationTitle(.positional(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     internal struct Positional {
         enum BundleDescription {
             case main
@@ -243,6 +282,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘Positional‘ strings table.
     internal static func positional(_ positional: String.Positional) -> LocalizedStringResource {
         LocalizedStringResource(positional: positional)
     }
@@ -253,7 +293,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(positional: String.Positional) {
+    /// Creates a text view that displays a localized string defined in the ‘Positional‘ strings table.
+    internal init(positional: String.Positional) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(positional: positional))
             return
@@ -285,6 +326,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘Positional‘ strings table.
     internal init(positional: String.Positional) {
         let text = Text(positional: positional)
 
@@ -295,10 +337,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Positional‘ strings table.
     internal static func positional(_ positional: String.Positional) -> LocalizedStringKey {
         LocalizedStringKey(positional: positional)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -234,13 +234,17 @@ extension LocalizedStringResource {
 
     internal static let positional = Positional()
 
-    init(positional: String.Positional) {
+    internal init(positional: String.Positional) {
         self.init(
             positional.key,
             defaultValue: positional.defaultValue,
             table: positional.table,
             bundle: .from(description: positional.bundle)
         )
+    }
+
+    internal static func positional(_ positional: String.Positional) -> LocalizedStringResource {
+        LocalizedStringResource(positional: positional)
     }
 }
 
@@ -281,7 +285,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(positional: String.Positional) {
+    internal init(positional: String.Positional) {
         let text = Text(positional: positional)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -289,6 +293,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    internal static func positional(_ positional: String.Positional) -> LocalizedStringKey {
+        LocalizedStringKey(positional: positional)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -281,6 +281,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(positional: String.Positional) {
+        let text = Text(positional: positional)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -328,10 +328,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘Positional‘ strings table.
     internal init(positional: String.Positional) {
-        let text = Text(positional: positional)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(positional: positional))
+        } else {
+            stringInterpolation.appendInterpolation(Text(positional: positional))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -182,3 +182,50 @@ extension LocalizedStringResource {
         )
     }
 }
+
+#if canImport (SwiftUI)
+import SwiftUI
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension Text {
+    init(simple: String.Simple) {
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            self.init(LocalizedStringResource(simple: simple))
+            return
+        }
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: simple.arguments.count)
+        for argument in simple.arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+
+        var key = makeKey(stringInterpolation)
+        key.overrideKeyForLookup(using: simple.key)
+
+        self.init(key, tableName: simple.table, bundle: .from(description: simple.bundle))
+    }
+}
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension LocalizedStringKey {
+    fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
+        withUnsafeMutablePointer(to: &self) { pointer in
+            let raw = UnsafeMutableRawPointer(pointer)
+            let bound = raw.assumingMemoryBound(to: String.self)
+            bound.pointee = String(describing: key)
+        }
+    }
+}
+#endif

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     internal struct Simple {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -173,13 +173,17 @@ extension LocalizedStringResource {
 
     internal static let simple = Simple()
 
-    init(simple: String.Simple) {
+    internal init(simple: String.Simple) {
         self.init(
             simple.key,
             defaultValue: simple.defaultValue,
             table: simple.table,
             bundle: .from(description: simple.bundle)
         )
+    }
+
+    internal static func simple(_ simple: String.Simple) -> LocalizedStringResource {
+        LocalizedStringResource(simple: simple)
     }
 }
 
@@ -220,7 +224,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(simple: String.Simple) {
+    internal init(simple: String.Simple) {
         let text = Text(simple: simple)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -228,6 +232,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    internal static func simple(_ simple: String.Simple) -> LocalizedStringKey {
+        LocalizedStringKey(simple: simple)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -220,6 +220,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(simple: String.Simple) {
+        let text = Text(simple: simple)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -267,10 +267,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘Simple‘ strings table.
     internal init(simple: String.Simple) {
-        let text = Text(simple: simple)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(simple: simple))
+        } else {
+            stringInterpolation.appendInterpolation(Text(simple: simple))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the Simple Strings Catalog
+    /// A type that represents localized strings from the ‘Simple‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(simple:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(simple: .simpleKey)
     /// value // "My Value"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(simple: .simpleKey)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(simple:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/simple(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(simple: .listContent)
+    ///     }
+    ///     .navigationTitle(.simple(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     internal struct Simple {
         enum BundleDescription {
             case main
@@ -182,6 +221,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘Simple‘ strings table.
     internal static func simple(_ simple: String.Simple) -> LocalizedStringResource {
         LocalizedStringResource(simple: simple)
     }
@@ -192,7 +232,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(simple: String.Simple) {
+    /// Creates a text view that displays a localized string defined in the ‘Simple‘ strings table.
+    internal init(simple: String.Simple) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(simple: simple))
             return
@@ -224,6 +265,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘Simple‘ strings table.
     internal init(simple: String.Simple) {
         let text = Text(simple: simple)
 
@@ -234,10 +276,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Simple‘ strings table.
     internal static func simple(_ simple: String.Simple) -> LocalizedStringKey {
         LocalizedStringKey(simple: simple)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -224,6 +224,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(substitution: String.Substitution) {
+        let text = Text(substitution: substitution)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -186,3 +186,50 @@ extension LocalizedStringResource {
         )
     }
 }
+
+#if canImport (SwiftUI)
+import SwiftUI
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension Text {
+    init(substitution: String.Substitution) {
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            self.init(LocalizedStringResource(substitution: substitution))
+            return
+        }
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: substitution.arguments.count)
+        for argument in substitution.arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+
+        var key = makeKey(stringInterpolation)
+        key.overrideKeyForLookup(using: substitution.key)
+
+        self.init(key, tableName: substitution.table, bundle: .from(description: substitution.bundle))
+    }
+}
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension LocalizedStringKey {
+    fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
+        withUnsafeMutablePointer(to: &self) { pointer in
+            let raw = UnsafeMutableRawPointer(pointer)
+            let bound = raw.assumingMemoryBound(to: String.self)
+            bound.pointee = String(describing: key)
+        }
+    }
+}
+#endif

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -271,10 +271,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘Substitution‘ strings table.
     internal init(substitution: String.Substitution) {
-        let text = Text(substitution: substitution)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(substitution: substitution))
+        } else {
+            stringInterpolation.appendInterpolation(Text(substitution: substitution))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the Substitution Strings Catalog
+    /// A type that represents localized strings from the ‘Substitution‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(substitution:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(substitution: .foo)
     /// value // "bar"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(substitution: .foo)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(substitution:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/substitution(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(substitution: .listContent)
+    ///     }
+    ///     .navigationTitle(.substitution(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     internal struct Substitution {
         enum BundleDescription {
             case main
@@ -186,6 +225,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘Substitution‘ strings table.
     internal static func substitution(_ substitution: String.Substitution) -> LocalizedStringResource {
         LocalizedStringResource(substitution: substitution)
     }
@@ -196,7 +236,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(substitution: String.Substitution) {
+    /// Creates a text view that displays a localized string defined in the ‘Substitution‘ strings table.
+    internal init(substitution: String.Substitution) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(substitution: substitution))
             return
@@ -228,6 +269,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘Substitution‘ strings table.
     internal init(substitution: String.Substitution) {
         let text = Text(substitution: substitution)
 
@@ -238,10 +280,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Substitution‘ strings table.
     internal static func substitution(_ substitution: String.Substitution) -> LocalizedStringKey {
         LocalizedStringKey(substitution: substitution)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -177,13 +177,17 @@ extension LocalizedStringResource {
 
     internal static let substitution = Substitution()
 
-    init(substitution: String.Substitution) {
+    internal init(substitution: String.Substitution) {
         self.init(
             substitution.key,
             defaultValue: substitution.defaultValue,
             table: substitution.table,
             bundle: .from(description: substitution.bundle)
         )
+    }
+
+    internal static func substitution(_ substitution: String.Substitution) -> LocalizedStringResource {
+        LocalizedStringResource(substitution: substitution)
     }
 }
 
@@ -224,7 +228,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(substitution: String.Substitution) {
+    internal init(substitution: String.Substitution) {
         let text = Text(substitution: substitution)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -232,6 +236,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    internal static func substitution(_ substitution: String.Substitution) -> LocalizedStringKey {
+        LocalizedStringKey(substitution: substitution)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     internal struct Substitution {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -198,13 +198,17 @@ extension LocalizedStringResource {
 
     internal static let variations = Variations()
 
-    init(variations: String.Variations) {
+    internal init(variations: String.Variations) {
         self.init(
             variations.key,
             defaultValue: variations.defaultValue,
             table: variations.table,
             bundle: .from(description: variations.bundle)
         )
+    }
+
+    internal static func variations(_ variations: String.Variations) -> LocalizedStringResource {
+        LocalizedStringResource(variations: variations)
     }
 }
 
@@ -245,7 +249,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(variations: String.Variations) {
+    internal init(variations: String.Variations) {
         let text = Text(variations: variations)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -253,6 +257,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    internal static func variations(_ variations: String.Variations) -> LocalizedStringKey {
+        LocalizedStringKey(variations: variations)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -292,10 +292,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘Variations‘ strings table.
     internal init(variations: String.Variations) {
-        let text = Text(variations: variations)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(variations: variations))
+        } else {
+            stringInterpolation.appendInterpolation(Text(variations: variations))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -245,6 +245,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(variations: String.Variations) {
+        let text = Text(variations: variations)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the Variations Strings Catalog
+    /// A type that represents localized strings from the ‘Variations‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(variations:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(variations: .stringDevice)
     /// value // "Tap to open"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(variations: .stringDevice)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(variations:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/variations(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(variations: .listContent)
+    ///     }
+    ///     .navigationTitle(.variations(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     internal struct Variations {
         enum BundleDescription {
             case main
@@ -207,6 +246,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘Variations‘ strings table.
     internal static func variations(_ variations: String.Variations) -> LocalizedStringResource {
         LocalizedStringResource(variations: variations)
     }
@@ -217,7 +257,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(variations: String.Variations) {
+    /// Creates a text view that displays a localized string defined in the ‘Variations‘ strings table.
+    internal init(variations: String.Variations) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(variations: variations))
             return
@@ -249,6 +290,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘Variations‘ strings table.
     internal init(variations: String.Variations) {
         let text = Text(variations: variations)
 
@@ -259,10 +301,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Variations‘ strings table.
     internal static func variations(_ variations: String.Variations) -> LocalizedStringKey {
         LocalizedStringKey(variations: variations)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     internal struct Variations {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -294,6 +294,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(localizable: String.Localizable) {
+        let text = Text(localizable: localizable)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -247,13 +247,17 @@ extension LocalizedStringResource {
 
     package static let localizable = Localizable()
 
-    init(localizable: String.Localizable) {
+    package init(localizable: String.Localizable) {
         self.init(
             localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
             bundle: .from(description: localizable.bundle)
         )
+    }
+
+    package static func localizable(_ localizable: String.Localizable) -> LocalizedStringResource {
+        LocalizedStringResource(localizable: localizable)
     }
 }
 
@@ -294,7 +298,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(localizable: String.Localizable) {
+    package init(localizable: String.Localizable) {
         let text = Text(localizable: localizable)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -302,6 +306,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    package static func localizable(_ localizable: String.Localizable) -> LocalizedStringKey {
+        LocalizedStringKey(localizable: localizable)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the Localizable Strings Catalog
+    /// A type that represents localized strings from the ‘Localizable‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(localizable:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(localizable: .key)
     /// value // "Default Value"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(localizable: .key)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(localizable:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/localizable(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(localizable: .listContent)
+    ///     }
+    ///     .navigationTitle(.localizable(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     package struct Localizable {
         enum BundleDescription {
             case main
@@ -256,6 +295,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘Localizable‘ strings table.
     package static func localizable(_ localizable: String.Localizable) -> LocalizedStringResource {
         LocalizedStringResource(localizable: localizable)
     }
@@ -266,7 +306,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(localizable: String.Localizable) {
+    /// Creates a text view that displays a localized string defined in the ‘Localizable‘ strings table.
+    package init(localizable: String.Localizable) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(localizable: localizable))
             return
@@ -298,6 +339,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘Localizable‘ strings table.
     package init(localizable: String.Localizable) {
         let text = Text(localizable: localizable)
 
@@ -308,10 +350,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Localizable‘ strings table.
     package static func localizable(_ localizable: String.Localizable) -> LocalizedStringKey {
         LocalizedStringKey(localizable: localizable)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -341,10 +341,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘Localizable‘ strings table.
     package init(localizable: String.Localizable) {
-        let text = Text(localizable: localizable)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(localizable: localizable))
+        } else {
+            stringInterpolation.appendInterpolation(Text(localizable: localizable))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -256,3 +256,50 @@ extension LocalizedStringResource {
         )
     }
 }
+
+#if canImport (SwiftUI)
+import SwiftUI
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension Text {
+    init(localizable: String.Localizable) {
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            self.init(LocalizedStringResource(localizable: localizable))
+            return
+        }
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: localizable.arguments.count)
+        for argument in localizable.arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+
+        var key = makeKey(stringInterpolation)
+        key.overrideKeyForLookup(using: localizable.key)
+
+        self.init(key, tableName: localizable.table, bundle: .from(description: localizable.bundle))
+    }
+}
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension LocalizedStringKey {
+    fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
+        withUnsafeMutablePointer(to: &self) { pointer in
+            let raw = UnsafeMutableRawPointer(pointer)
+            let bound = raw.assumingMemoryBound(to: String.self)
+            bound.pointee = String(describing: key)
+        }
+    }
+}
+#endif

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     package struct Localizable {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -1,13 +1,52 @@
 import Foundation
 
 extension String {
-    /// Constant values for the Localizable Strings Catalog
+    /// A type that represents localized strings from the ‘Localizable‘
+    /// strings table.
+    ///
+    /// Do not initialize instances of this type yourself, instead use one of the static
+    /// methods or properties that have been generated automatically.
+    ///
+    /// ## Usage
+    ///
+    /// ### Foundation
+    ///
+    /// In Foundation, you can resolve the localized string using the system language
+    /// with the `String`.``Swift/String/init(localizable:locale:)``
+    /// intializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly
     /// let value = String(localizable: .key)
     /// value // "Default Value"
     /// ```
+    ///
+    /// Starting in iOS 16/macOS 13/tvOS 16/watchOS 9, `LocalizedStringResource` can also
+    /// be used:
+    ///
+    /// ```swift
+    /// var resource = LocalizedStringResource(localizable: .key)
+    /// resource.locale = Locale(identifier: "fr") // customise language
+    /// let value = String(localized: resource)    // defer lookup
+    /// ```
+    ///
+    /// ### SwiftUI
+    ///
+    /// In SwiftUI, it is recommended to use `Text`.``SwiftUI/Text/init(localizable:)``
+    /// or `LocalizedStringKey`.``SwiftUI/LocalizedStringKey/localizable(_:)``
+    /// in order for localized values to be resolved within the SwiftUI environment:
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     List {
+    ///         Text(localizable: .listContent)
+    ///     }
+    ///     .navigationTitle(.localizable(.navigationTitle))
+    ///     .environment(\.locale, Locale(identifier: "fr"))
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
     public struct Localizable {
         enum BundleDescription {
             case main
@@ -256,6 +295,7 @@ extension LocalizedStringResource {
         )
     }
 
+    /// Creates a `LocalizedStringResource` that represents a localized value in the ‘Localizable‘ strings table.
     public static func localizable(_ localizable: String.Localizable) -> LocalizedStringResource {
         LocalizedStringResource(localizable: localizable)
     }
@@ -266,7 +306,8 @@ import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension Text {
-    init(localizable: String.Localizable) {
+    /// Creates a text view that displays a localized string defined in the ‘Localizable‘ strings table.
+    public init(localizable: String.Localizable) {
         if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(localizable: localizable))
             return
@@ -298,6 +339,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    /// Creates a localized string key that represents a localized value in the ‘Localizable‘ strings table.
     public init(localizable: String.Localizable) {
         let text = Text(localizable: localizable)
 
@@ -308,10 +350,19 @@ extension LocalizedStringKey {
         self = makeKey(stringInterpolation)
     }
 
+    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Localizable‘ strings table.
     public static func localizable(_ localizable: String.Localizable) -> LocalizedStringKey {
         LocalizedStringKey(localizable: localizable)
     }
 
+    /// Updates the underlying `key` used when performing localization lookups.
+    ///
+    /// By default, an instance of `LocalizedStringKey` can only be created
+    /// using string interpolation, so if arguments are included, the format
+    /// specifiers make up part of the key.
+    ///
+    /// This method allows you to change the key after initialization in order
+    /// to match the value that might be defined in the strings table.
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -294,6 +294,16 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
+    init(localizable: String.Localizable) {
+        let text = Text(localizable: localizable)
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
+        stringInterpolation.appendInterpolation(text)
+
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+        self = makeKey(stringInterpolation)
+    }
+
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -46,7 +46,7 @@ extension String {
     /// }
     /// ```
     ///
-    /// - SeeAlso: [XCStrings Tool Documentation](https://swiftpackageindex.com/liamnichols/xcstrings-tool/documentation/documentation/using-the-generated-source-code)
+    /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
     public struct Localizable {
         enum BundleDescription {
             case main

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -256,3 +256,50 @@ extension LocalizedStringResource {
         )
     }
 }
+
+#if canImport (SwiftUI)
+import SwiftUI
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension Text {
+    init(localizable: String.Localizable) {
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            self.init(LocalizedStringResource(localizable: localizable))
+            return
+        }
+
+        var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: localizable.arguments.count)
+        for argument in localizable.arguments {
+            switch argument {
+            case .int(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .uint(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .float(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .double(let value):
+                stringInterpolation.appendInterpolation(value)
+            case .object(let value):
+                stringInterpolation.appendInterpolation(value)
+            }
+        }
+        let makeKey = LocalizedStringKey.init(stringInterpolation:)
+
+        var key = makeKey(stringInterpolation)
+        key.overrideKeyForLookup(using: localizable.key)
+
+        self.init(key, tableName: localizable.table, bundle: .from(description: localizable.bundle))
+    }
+}
+
+@available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
+extension LocalizedStringKey {
+    fileprivate mutating func overrideKeyForLookup(using key: StaticString) {
+        withUnsafeMutablePointer(to: &self) { pointer in
+            let raw = UnsafeMutableRawPointer(pointer)
+            let bound = raw.assumingMemoryBound(to: String.self)
+            bound.pointee = String(describing: key)
+        }
+    }
+}
+#endif

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -247,13 +247,17 @@ extension LocalizedStringResource {
 
     public static let localizable = Localizable()
 
-    init(localizable: String.Localizable) {
+    public init(localizable: String.Localizable) {
         self.init(
             localizable.key,
             defaultValue: localizable.defaultValue,
             table: localizable.table,
             bundle: .from(description: localizable.bundle)
         )
+    }
+
+    public static func localizable(_ localizable: String.Localizable) -> LocalizedStringResource {
+        LocalizedStringResource(localizable: localizable)
     }
 }
 
@@ -294,7 +298,7 @@ extension Text {
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)
 extension LocalizedStringKey {
-    init(localizable: String.Localizable) {
+    public init(localizable: String.Localizable) {
         let text = Text(localizable: localizable)
 
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
@@ -302,6 +306,10 @@ extension LocalizedStringKey {
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)
+    }
+
+    public static func localizable(_ localizable: String.Localizable) -> LocalizedStringKey {
+        LocalizedStringKey(localizable: localizable)
     }
 
     fileprivate mutating func overrideKeyForLookup(using key: StaticString) {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -341,10 +341,13 @@ extension Text {
 extension LocalizedStringKey {
     /// Creates a localized string key that represents a localized value in the ‘Localizable‘ strings table.
     public init(localizable: String.Localizable) {
-        let text = Text(localizable: localizable)
-
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
-        stringInterpolation.appendInterpolation(text)
+
+        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+            stringInterpolation.appendInterpolation(LocalizedStringResource(localizable: localizable))
+        } else {
+            stringInterpolation.appendInterpolation(Text(localizable: localizable))
+        }
 
         let makeKey = LocalizedStringKey.init(stringInterpolation:)
         self = makeKey(stringInterpolation)


### PR DESCRIPTION
Closes #60 

While `LocalizedStringResource` might be the future, it's still not in a place today where it can be used all of the time. Much of SwiftUI still does not support this type and it's also not compatible with older OS versions.

Since we've already put the effort in to support older OSes in Foundation (#70, #50), it makes sense to do the same for SwiftUI.

This Pull Request brings some creative little extensions on top of `Text` and `LocalizedStringKey` that let you use the generated `String.Localizable` type across the entire API surface of SwiftUI on any OS version 🎉 

It does so with the following extensions:

```swift
extension Text {
    /// Creates a text view that displays a localized string defined in the ‘Localizable‘ strings table.
    internal init(localizable: String.Localizable)
}

extension LocalizedStringKey {
    /// Creates a localized string key that represents a localized value in the ‘Localizable‘ strings table.
    internal init(localizable: String.Localizable)
    
    /// Creates a `LocalizedStringKey` that represents a localized value in the ‘Localizable‘ strings table.
    internal static func localizable(_ localizable: String.Localizable) -> LocalizedStringKey
}
```

Which allow for usage like the following:

```swift
struct ContentView: View {
    @Query var items: [Item]

    var body: some View {
        List {
            Section {
                ForEach(items) { item in
                    ItemView(item)
                }
            } footer: {
                Text(.localizable(.footerText(items.count)))
            }
        }
        .navigationTitle(.localizable(.contentViewTitle))
    }
}
```

In addition to the new extensions, I've also improved the documentation that is generated inline, as well as the documentation hosted in this repo.