### PR TITLE
Use Existential `any`

### DIFF
--- a/Sources/StringGenerator/Snippets/String/StringsTable/Argument/StringStringsTableArgumentValueComputedProperty.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/Argument/StringStringsTableArgumentValueComputedProperty.swift
@@ -6,12 +6,15 @@ struct StringStringsTableArgumentValueComputedProperty: Snippet {
     let argumentEnum: SourceFile.StringExtension.StringsTableStruct.ArgumentEnum
 
     var syntax: some DeclSyntaxProtocol {
-        // var value: CVarArg { ... }
+        // var value: any CVarArg { ... }
         VariableDeclSyntax(bindingSpecifier: .keyword(.var)) {
             PatternBindingSyntax(
                 pattern: IdentifierPatternSyntax(identifier: .identifier("value")),
                 typeAnnotation: TypeAnnotationSyntax(
-                    type: .identifier(.CVarArg)
+                    type: SomeOrAnyTypeSyntax(
+                        someOrAnySpecifier: .keyword(.any),
+                        constraint: .identifier(.CVarArg)
+                    )
                 ),
                 accessorBlock: AccessorBlockSyntax(
                     accessors: .getter(CodeBlockItemListSyntax {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -74,7 +74,7 @@ extension String {
             case double(Double)
             case object(String)
 
-            var value: CVarArg {
+            var value: any CVarArg {
                 switch self {
                 case .int(let value):
                     value


### PR DESCRIPTION
The computed `value` property on the `Argument` enum was defined as `CVarArg`, which will result in a build failure in future versions of Swift.

![screenshot_2024-05-28_at_8 40 44___pm](https://github.com/liamnichols/xcstrings-tool/assets/482871/32acb031-0450-4044-a6b6-7a05c2b17cdc)

We should include the `any` keyword.
