### PR TITLE
Add Sendable conformance to generated struct

### DIFF
--- a/Sources/StringGenerator/Extensions/InheritanceClauseSyntax.swift
+++ b/Sources/StringGenerator/Extensions/InheritanceClauseSyntax.swift
@@ -1,0 +1,16 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension InheritanceClauseSyntax {
+    init(_ types: TokenSyntax.MetaType...) {
+        self.init(types)
+    }
+
+    init(_ types: [TokenSyntax.MetaType]) {
+        self.init {
+            for type in types {
+                InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .type(type)))
+            }
+        }
+    }
+}

--- a/Sources/StringGenerator/Extensions/TokenSyntax+Types.swift
+++ b/Sources/StringGenerator/Extensions/TokenSyntax+Types.swift
@@ -21,6 +21,7 @@ extension TokenSyntax {
         case CVarArg
         case LocalizedStringKey
         case Text
+        case Sendable
     }
 
     static func type(_ value: MetaType) -> TokenSyntax {

--- a/Sources/StringGenerator/Snippets/String/StringsTable/Argument/StringStringsTableArgumentEnumSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/Argument/StringStringsTableArgumentEnumSnippet.swift
@@ -5,7 +5,7 @@ struct StringStringsTableArgumentEnumSnippet: Snippet {
     let argument: SourceFile.StringExtension.StringsTableStruct.ArgumentEnum
 
     var syntax: some DeclSyntaxProtocol {
-        EnumDeclSyntax(name: argument.type) {
+        EnumDeclSyntax(name: argument.type, inheritanceClause: inheritanceClause) {
             MemberBlockItemListSyntax {
                 for enumCase in argument.cases {
                     Case(enumCase: enumCase)
@@ -17,6 +17,10 @@ struct StringStringsTableArgumentEnumSnippet: Snippet {
                 argumentEnum: argument
             )
         }
+    }
+
+    var inheritanceClause: InheritanceClauseSyntax? {
+        InheritanceClauseSyntax(.Sendable)
     }
 }
 

--- a/Sources/StringGenerator/Snippets/String/StringsTable/BundleDescription/StringStringsTableBundleDescriptionEnumSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/BundleDescription/StringStringsTableBundleDescriptionEnumSnippet.swift
@@ -14,7 +14,7 @@ struct StringStringsTableBundleDescriptionEnumSnippet: Snippet {
     let bundleDescription: SourceFile.StringExtension.StringsTableStruct.BundleDescriptionEnum
 
     var syntax: some DeclSyntaxProtocol {
-        EnumDeclSyntax(name: bundleDescription.type) {
+        EnumDeclSyntax(name: bundleDescription.type, inheritanceClause: inheritanceClause) {
             MemberBlockItemListSyntax {
                 for enumCase in bundleDescription.cases {
                     Case(enumCase: enumCase)
@@ -33,6 +33,10 @@ struct StringStringsTableBundleDescriptionEnumSnippet: Snippet {
 
             StringStringsTableBundleDescriptionCurrentComputedPropertySnippet()
         }
+    }
+
+    var inheritanceClause: InheritanceClauseSyntax? {
+        InheritanceClauseSyntax(.Sendable)
     }
 }
 

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
@@ -7,17 +7,22 @@ struct StringStringsTableStructSnippet: Snippet {
 
     var syntax: some DeclSyntaxProtocol {
         // /// headerdoc
-        // public struct Localizable { ... }
+        // public struct Localizable: Sendable { ... }
         StructDeclSyntax(
             leadingTrivia: leadingTrivia,
             modifiers: modifiers,
             name: stringsTable.type,
+            inheritanceClause: inheritanceClause,
             memberBlock: memberBlock
         )
     }
 
     var leadingTrivia: Trivia? {
         Trivia(docComment: stringsTable.headerDocumentation)
+    }
+
+    var inheritanceClause: InheritanceClauseSyntax? {
+        InheritanceClauseSyntax(.Sendable)
     }
 
     var memberBlock: MemberBlockSyntax {

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    internal struct FormatSpecifiers {
-        enum BundleDescription {
+    internal struct FormatSpecifiers: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    internal struct Localizable {
-        enum BundleDescription {
+    internal struct Localizable: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    internal struct Multiline {
-        enum BundleDescription {
+    internal struct Multiline: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    internal struct Positional {
-        enum BundleDescription {
+    internal struct Positional: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    internal struct Simple {
-        enum BundleDescription {
+    internal struct Simple: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    internal struct Substitution {
-        enum BundleDescription {
+    internal struct Substitution: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    internal struct Variations {
-        enum BundleDescription {
+    internal struct Variations: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    package struct Localizable {
-        enum BundleDescription {
+    package struct Localizable: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -47,8 +47,8 @@ extension String {
     /// ```
     ///
     /// - SeeAlso: [XCStrings Tool Documentation - Using the generated source code](https://swiftpackageindex.com/liamnichols/xcstrings-tool/0.3.0/documentation/documentation/using-the-generated-source-code)
-    public struct Localizable {
-        enum BundleDescription {
+    public struct Localizable: Sendable {
+        enum BundleDescription: Sendable {
             case main
             case atURL(URL)
             case forClass(AnyClass)
@@ -67,7 +67,7 @@ extension String {
             }
         }
 
-        enum Argument {
+        enum Argument: Sendable {
             case int(Int)
             case uint(UInt)
             case float(Float)


### PR DESCRIPTION
The generated struct didn't include `Sendable` conformance, which can lead to compiler warnings/issues when using strict concurrency checks.

This Pull Request annotates the generated struct, as well as the `Argument` and `BundleDescription` enums.