### PR TITLE
soft-deprecate old generated LocalizedStringResource extensions

### DIFF
--- a/Sources/StringGenerator/Extensions/AttributeSyntax+Availability.swift
+++ b/Sources/StringGenerator/Extensions/AttributeSyntax+Availability.swift
@@ -9,6 +9,32 @@ extension AttributeSyntax {
             rightParen: .rightParenToken()
         )
     }
+
+    init(
+        _ platform: TokenSyntax,
+        deprecated version: Int?,
+        message: String
+    ) {
+        self.init(TypeSyntax(IdentifierTypeSyntax(name: .keyword(.available)))) {
+            LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: platform))
+
+            if let version {
+                LabeledExprSyntax(
+                    label: "deprecated",
+                    expression: IntegerLiteralExprSyntax(version)
+                )
+            } else {
+                LabeledExprSyntax(
+                    expression: DeclReferenceExprSyntax(baseName: .identifier("deprecated"))
+                )
+            }
+
+            LabeledExprSyntax(
+                label: "message",
+                expression: StringLiteralExprSyntax(content: message)
+            )
+        }
+    }
 }
 
 extension AvailabilityArgumentListSyntax {

--- a/Sources/StringGenerator/Models/SourceFile_LocalizedStringResourceExtension_StringsTableStruct_ResourceAccessor.swift
+++ b/Sources/StringGenerator/Models/SourceFile_LocalizedStringResourceExtension_StringsTableStruct_ResourceAccessor.swift
@@ -18,6 +18,18 @@ extension SourceFile.LocalizedStringResourceExtension.StringsTableStruct {
             IdentifierTypeSyntax(name: .type(.LocalizedStringResource))
         }
 
+        var alternativeSignature: String {
+            let type = sourceFile.stringExtension.stringsTableStruct.fullyQualifiedType.map(\.text).joined(separator: ".")
+            let name = resource.identifier
+
+            if hasArguments {
+                let arguments = resource.arguments.map({ "\($0.label ?? "_"):" }).joined()
+                return "\(type).\(name)(\(arguments))"
+            } else {
+                return "\(type).\(name)"
+            }
+        }
+
         var headerDocumentation: String {
             var docComponents: [String] = []
 

--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/LocalizedStringResourceStringsTableComputedPropertySnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/LocalizedStringResourceStringsTableComputedPropertySnippet.swift
@@ -9,6 +9,7 @@ extension LocalizedStringResourceStringsTableComputedPropertySnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
         // internal static let localizable = Localizable()
         VariableDeclSyntax(
+            attributes: attributes.map({ $0.with(\.trailingTrivia, .newline) }),
             modifiers: modifiers,
             .let,
             name: PatternSyntax(IdentifierPatternSyntax(
@@ -25,6 +26,22 @@ extension LocalizedStringResourceStringsTableComputedPropertySnippet: Snippet {
                 )
             )
         )
+    }
+
+    var deprecationMessage: String {
+        """
+        Use the `\(sourceFile.tableVariableIdentifier)(_:)` static method instead. \
+        This property will be removed in the future.
+        """
+    }
+
+    @AttributeListBuilder
+    var attributes: AttributeListSyntax {
+        AttributeSyntax(.identifier("iOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("macOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("tvOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("watchOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("visionOS"), deprecated: 100000, message: deprecationMessage)
     }
 
     @DeclModifierListBuilder

--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableResourceFunctionSnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableResourceFunctionSnippet.swift
@@ -7,6 +7,7 @@ struct LocalizedStringResourceStringsTableResourceFunctionSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
         FunctionDeclSyntax(
             leadingTrivia: leadingTrivia,
+            attributes: attributes.map({ $0.with(\.trailingTrivia, .newline) }),
             modifiers: modifiers,
             name: accessor.name,
             signature: FunctionSignatureSyntax(
@@ -23,6 +24,22 @@ struct LocalizedStringResourceStringsTableResourceFunctionSnippet: Snippet {
 
     var leadingTrivia: Trivia? {
         Trivia(docComment: accessor.headerDocumentation)
+    }
+
+    var deprecationMessage: String {
+        """
+        Use `\(accessor.alternativeSignature)` instead. \
+        This method will be removed in the future.
+        """
+    }
+
+    @AttributeListBuilder
+    var attributes: AttributeListSyntax {
+        AttributeSyntax(.identifier("iOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("macOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("tvOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("watchOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("visionOS"), deprecated: 100000, message: deprecationMessage)
     }
 
     @DeclModifierListBuilder

--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableResourceVariableSnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableResourceVariableSnippet.swift
@@ -7,6 +7,7 @@ struct LocalizedStringResourceStringsTableResourceVariableSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
         VariableDeclSyntax(
             leadingTrivia: leadingTrivia,
+            attributes: attributes.map({ $0.with(\.trailingTrivia, .newline) }),
             modifiers: modifiers,
             bindingSpecifier: .keyword(.var),
             bindings: [
@@ -23,6 +24,22 @@ struct LocalizedStringResourceStringsTableResourceVariableSnippet: Snippet {
 
     var leadingTrivia: Trivia? {
         Trivia(docComment: accessor.headerDocumentation)
+    }
+
+    var deprecationMessage: String {
+        """
+        Use `\(accessor.alternativeSignature)` instead. \
+        This property will be removed in the future.
+        """
+    }
+
+    @AttributeListBuilder
+    var attributes: AttributeListSyntax {
+        AttributeSyntax(.identifier("iOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("macOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("tvOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("watchOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.identifier("visionOS"), deprecated: 100000, message: deprecationMessage)
     }
 
     @DeclModifierListBuilder

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -415,6 +415,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %@
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
         internal func at(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .at(arg1))
         }
@@ -426,6 +431,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %d
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
         internal func d(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d(arg1))
         }
@@ -437,6 +447,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %lld
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
         internal func d_length(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d_length(arg1))
         }
@@ -448,6 +463,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %f
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
         internal func f(_ arg1: Double) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .f(arg1))
         }
@@ -459,6 +479,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %.2f
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
         internal func f_precision(_ arg1: Double) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .f_precision(arg1))
         }
@@ -470,6 +495,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %i
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
         internal func i(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .i(arg1))
         }
@@ -481,6 +511,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %o
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
         internal func o(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .o(arg1))
         }
@@ -492,6 +527,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
         internal var percentage: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage)
         }
@@ -503,6 +543,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %%
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
         internal var percentage_escaped: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_escaped)
         }
@@ -514,6 +559,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test 50%% off
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
         internal var percentage_escaped_space_o: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_escaped_space_o)
         }
@@ -525,6 +575,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test 50% off
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
         internal var percentage_space_o: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_space_o)
         }
@@ -536,6 +591,11 @@ extension LocalizedStringResource {
         /// ```
         /// Test %u
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
         internal func u(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .u(arg1))
         }
@@ -547,12 +607,21 @@ extension LocalizedStringResource {
         /// ```
         /// Test %x
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
         internal func x(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .x(arg1))
         }
     }
 
-    internal static let formatSpecifiers = FormatSpecifiers()
+    @available (iOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.") internal static let formatSpecifiers = FormatSpecifiers()
 
     internal init(formatSpecifiers: String.FormatSpecifiers) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -252,6 +252,11 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         internal var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -261,6 +266,11 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         internal var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -270,6 +280,11 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         internal func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -279,12 +294,21 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         internal func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    internal static let localizable = Localizable()
+    @available (iOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") internal static let localizable = Localizable()
 
     internal init(localizable: String.Localizable) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -215,12 +215,21 @@ extension LocalizedStringResource {
         /// - Two
         /// - Three
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
         internal var multiline: LocalizedStringResource {
             LocalizedStringResource(multiline: .multiline)
         }
     }
 
-    internal static let multiline = Multiline()
+    @available (iOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.") internal static let multiline = Multiline()
 
     internal init(multiline: String.Multiline) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -244,6 +244,11 @@ extension LocalizedStringResource {
         /// ```
         /// Second: %2$@ - First: %1$lld
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
         internal func reorder(_ arg1: Int, _ arg2: String) -> LocalizedStringResource {
             LocalizedStringResource(positional: .reorder(arg1, arg2))
         }
@@ -255,6 +260,11 @@ extension LocalizedStringResource {
         /// ```
         /// %1$lld, I repeat: %1$lld
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
         internal func repeatExplicit(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(positional: .repeatExplicit(arg1))
         }
@@ -266,12 +276,21 @@ extension LocalizedStringResource {
         /// ```
         /// %@, are you there? %1$@?
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
         internal func repeatImplicit(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(positional: .repeatImplicit(arg1))
         }
     }
 
-    internal static let positional = Positional()
+    @available (iOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.") internal static let positional = Positional()
 
     internal init(positional: String.Positional) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -205,12 +205,21 @@ extension LocalizedStringResource {
         /// ```
         /// My Value
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
         internal var simpleKey: LocalizedStringResource {
             LocalizedStringResource(simple: .simpleKey)
         }
     }
 
-    internal static let simple = Simple()
+    @available (iOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.") internal static let simple = Simple()
 
     internal init(simple: String.Simple) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -209,12 +209,21 @@ extension LocalizedStringResource {
         /// ```
         /// %@! There are %lld strings and you have %lld remaining
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
         internal func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> LocalizedStringResource {
             LocalizedStringResource(substitution: .substitutions_exampleString(arg1, totalStrings: arg2, remainingStrings: arg3))
         }
     }
 
-    internal static let substitution = Substitution()
+    @available (iOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.") internal static let substitution = Substitution()
 
     internal init(substitution: String.Substitution) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -221,6 +221,11 @@ extension LocalizedStringResource {
         /// ```
         /// Tap to open
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
         internal var stringDevice: LocalizedStringResource {
             LocalizedStringResource(variations: .stringDevice)
         }
@@ -230,12 +235,21 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld strings
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
         internal func stringPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(variations: .stringPlural(arg1))
         }
     }
 
-    internal static let variations = Variations()
+    @available (iOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.") internal static let variations = Variations()
 
     internal init(variations: String.Variations) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -252,6 +252,11 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         package var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -261,6 +266,11 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         package var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -270,6 +280,11 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         package func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -279,12 +294,21 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         package func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    package static let localizable = Localizable()
+    @available (iOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") package static let localizable = Localizable()
 
     package init(localizable: String.Localizable) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -252,6 +252,11 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         public var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -261,6 +266,11 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         public var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -270,6 +280,11 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         public func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -279,12 +294,21 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
+        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         public func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    public static let localizable = Localizable()
+    @available (iOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (macOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (tvOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (watchOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
+    @available (visionOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") public static let localizable = Localizable()
 
     public init(localizable: String.Localizable) {
         self.init(


### PR DESCRIPTION
Closes #81 

In #82, we've introduced the static `LocalizedStringResource.localizable(_:)` method which allows you to use `String.Localizable` in order to create a `LocalizedStringResource` instance with the similar sugar that `LocalizedStringResource.String...` and `LocalizedStringResource.localizable` provided:

```diff
- Text(.localizable.foo)
+ Text(.localizable(.foo))
```

It's not so obvious what the difference is with type inference, so to explain some more:

```diff
- Text(LocalizedStringResource.localizable.foo)
+ Text(LocalizedStringResource.localizable(String.Localizable.foo))
```

This means that it's no longer worth the effort to generate `LocalizedStringResource.String` and as a result, we're going to remove it.

Before doing that though, I am going to mark it as soft-deprecated. This means to add the deprecation annotation but without triggering a warning (by setting the version number to 100000).

This will go live with 0.4.0. Then, in 0.5.0, I'll make the deprecation produce a warning and in 1.0.0, i'll remove the legacy generated code entirely.