### PR TITLE
Feature: Swift 6 preparation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -135,6 +135,37 @@ let package = Package(
     ]
 )
 
+// Use https://www.swift.org/swift-evolution/ to see details of the upcoming/experimental features
+let upcomingFeatureSwiftSettings: [SwiftSetting] = [
+    "ConciseMagicFile", // SE-0274
+    "ForwardTrailingClosures", // SE-0286
+    "ExistentialAny", // SE-0335
+    "BareSlashRegexLiterals", // SE-0354
+    "ImportObjcForwardDeclarations", // SE-0384
+    "DeprecateApplicationMain", // SE-0383
+    "DisableOutwardActorInference", // SE-0401
+    "IsolatedDefaultValues", // SE-0411
+    "GlobalConcurrency" // SE-0412
+].map {
+    .enableUpcomingFeature($0)
+}
+
+let experimentalFeatureSwiftSettings: [SwiftSetting] = [
+    "AccessLevelOnImport",  // SE-0409
+    "StrictConcurrency" // SE-0412
+].map {
+    .enableExperimentalFeature($0)
+}
+
+package.targets.forEach { target in
+    guard target.name != "XCStringsToolPlugin" else {
+        return /// Plugins don't support setting `swiftSettings`
+    }
+
+    let swiftSettings = target.swiftSettings ?? []
+    target.swiftSettings = swiftSettings + upcomingFeatureSwiftSettings + experimentalFeatureSwiftSettings
+}
+
 // https://swiftpackageindex.com/swiftpackageindex/spimanifest/0.19.0/documentation/spimanifest/validation
 // On CI, we want to validate the manifest, but nobody else needs that.
 if ProcessInfo.processInfo.environment.keys.contains("VALIDATE_SPI_MANIFEST") {

--- a/Package.swift
+++ b/Package.swift
@@ -159,7 +159,7 @@ let experimentalFeatureSwiftSettings: [SwiftSetting] = [
 
 package.targets.forEach { target in
     guard target.name != "XCStringsToolPlugin" else {
-        return /// Plugins don't support setting `swiftSettings`
+        return // Plugins don't support setting `swiftSettings`
     }
 
     let swiftSettings = target.swiftSettings ?? []

--- a/Sources/StringCatalog/Types/StringExtractionState.swift
+++ b/Sources/StringCatalog/Types/StringExtractionState.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct StringExtractionState: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral {
+public struct StringExtractionState: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral, Sendable {
     public let rawValue: String
 
     public init(rawValue: String) {

--- a/Sources/StringCatalog/Types/StringLanguage.swift
+++ b/Sources/StringCatalog/Types/StringLanguage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct StringLanguage: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral, CodingKeyRepresentable {
+public struct StringLanguage: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral, CodingKeyRepresentable, Sendable {
     public let rawValue: String
 
     public init(rawValue: String) {

--- a/Sources/StringCatalog/Types/StringUnitState.swift
+++ b/Sources/StringCatalog/Types/StringUnitState.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct StringUnitState: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral {
+public struct StringUnitState: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral, Sendable {
     public let rawValue: String
 
     public init(rawValue: String) {

--- a/Sources/StringCatalog/Types/StringVariations.swift
+++ b/Sources/StringCatalog/Types/StringVariations.swift
@@ -11,7 +11,7 @@ public struct StringVariations: Codable {
 }
 
 extension StringVariations {
-    public struct DeviceKey: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral, CodingKeyRepresentable {
+    public struct DeviceKey: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral, CodingKeyRepresentable, Sendable {
         public let rawValue: String
 
         public init(rawValue: String) {
@@ -32,7 +32,7 @@ extension StringVariations {
         public static let other = Self(rawValue: "other")
     }
 
-    public struct PluralKey: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral, CodingKeyRepresentable {
+    public struct PluralKey: Codable, Hashable, RawRepresentable, ExpressibleByStringLiteral, CodingKeyRepresentable, Sendable {
         public let rawValue: String
 
         public init(rawValue: String) {

--- a/Sources/StringExtractor/ExtractionError.swift
+++ b/Sources/StringExtractor/ExtractionError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum ExtractionError: Error {
-    public struct Context: Codable, Sendable {
+    public struct Context: Sendable {
         /// The key of the localization being parsed
         public let key: String
 

--- a/Sources/StringExtractor/ExtractionError.swift
+++ b/Sources/StringExtractor/ExtractionError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum ExtractionError: Error {
-  public struct Context: Codable, Sendable {
+    public struct Context: Codable, Sendable {
         /// The key of the localization being parsed
         public let key: String
 

--- a/Sources/StringExtractor/ExtractionError.swift
+++ b/Sources/StringExtractor/ExtractionError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum ExtractionError: Error {
-    public struct Context {
+  public struct Context: Codable, Sendable {
         /// The key of the localization being parsed
         public let key: String
 

--- a/Sources/xcstrings-tool/XCStringsTool.swift
+++ b/Sources/xcstrings-tool/XCStringsTool.swift
@@ -3,7 +3,7 @@ import XCStringsToolConstants
 
 @main
 struct XCStringsTool: ParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
         commandName: "xcstrings-tool",
         abstract: "Generates Swift code from String Catalogs (.xcstrings files)",
         version: version,

--- a/Tests/XCStringsToolTests/FixtureTestCase.swift
+++ b/Tests/XCStringsToolTests/FixtureTestCase.swift
@@ -11,7 +11,7 @@ class FixtureTestCase: XCTestCase {
         fixtures = try XCTUnwrap(bundle.urls(forResourcesWithExtension: "xcstrings", subdirectory: "__Fixtures__"))
     }
 
-    func eachFixture(_ test: (URL) throws -> Void) throws {
+  @MainActor func eachFixture(_ test: (URL) throws -> Void) throws {
         for fileURL in fixtures {
             try XCTContext.runActivity(named: fileURL.lastPathComponent) { activity in
                 do {

--- a/Tests/XCStringsToolTests/FixtureTestCase.swift
+++ b/Tests/XCStringsToolTests/FixtureTestCase.swift
@@ -1,7 +1,6 @@
 import Foundation
 import XCTest
 
-@MainActor
 class FixtureTestCase: XCTestCase {
     var fixtures: [URL]!
 
@@ -12,7 +11,7 @@ class FixtureTestCase: XCTestCase {
         fixtures = try XCTUnwrap(bundle.urls(forResourcesWithExtension: "xcstrings", subdirectory: "__Fixtures__"))
     }
 
-    func eachFixture(_ test: (URL) throws -> Void) throws {
+    @MainActor func eachFixture(_ test: (URL) throws -> Void) throws {
         for fileURL in fixtures {
             try XCTContext.runActivity(named: fileURL.lastPathComponent) { activity in
                 do {

--- a/Tests/XCStringsToolTests/FixtureTestCase.swift
+++ b/Tests/XCStringsToolTests/FixtureTestCase.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 class FixtureTestCase: XCTestCase {
     var fixtures: [URL]!
 
@@ -11,7 +12,7 @@ class FixtureTestCase: XCTestCase {
         fixtures = try XCTUnwrap(bundle.urls(forResourcesWithExtension: "xcstrings", subdirectory: "__Fixtures__"))
     }
 
-    @MainActor func eachFixture(_ test: (URL) throws -> Void) throws {
+    func eachFixture(_ test: (URL) throws -> Void) throws {
         for fileURL in fixtures {
             try XCTContext.runActivity(named: fileURL.lastPathComponent) { activity in
                 do {

--- a/Tests/XCStringsToolTests/FixtureTestCase.swift
+++ b/Tests/XCStringsToolTests/FixtureTestCase.swift
@@ -11,7 +11,7 @@ class FixtureTestCase: XCTestCase {
         fixtures = try XCTUnwrap(bundle.urls(forResourcesWithExtension: "xcstrings", subdirectory: "__Fixtures__"))
     }
 
-  @MainActor func eachFixture(_ test: (URL) throws -> Void) throws {
+    @MainActor func eachFixture(_ test: (URL) throws -> Void) throws {
         for fileURL in fixtures {
             try XCTContext.runActivity(named: fileURL.lastPathComponent) { activity in
                 do {

--- a/Tests/XCStringsToolTests/GenerateTests.swift
+++ b/Tests/XCStringsToolTests/GenerateTests.swift
@@ -3,8 +3,9 @@ import SnapshotTesting
 @testable import xcstrings_tool
 import XCTest
 
+@MainActor
 final class GenerateTests: FixtureTestCase {
-    @MainActor func testGenerate() throws {
+    func testGenerate() throws {
         try eachFixture { inputURL in
             if !inputURL.lastPathComponent.hasPrefix("!") {
                 try snapshot(for: inputURL)

--- a/Tests/XCStringsToolTests/GenerateTests.swift
+++ b/Tests/XCStringsToolTests/GenerateTests.swift
@@ -106,7 +106,7 @@ private extension GenerateTests {
 
         // Cleanup any temporary output
         addTeardownBlock {
-            let fileManager = FileManager.default /// Needed because `FileManager` is not `Sendable`
+            let fileManager = FileManager.default // Needed because `FileManager` is not `Sendable`
             if fileManager.fileExists(atPath: outputURL.path()) {
                 try? fileManager.removeItem(at: outputURL)
             }

--- a/Tests/XCStringsToolTests/GenerateTests.swift
+++ b/Tests/XCStringsToolTests/GenerateTests.swift
@@ -3,9 +3,8 @@ import SnapshotTesting
 @testable import xcstrings_tool
 import XCTest
 
-@MainActor
 final class GenerateTests: FixtureTestCase {
-    func testGenerate() throws {
+    @MainActor func testGenerate() throws {
         try eachFixture { inputURL in
             if !inputURL.lastPathComponent.hasPrefix("!") {
                 try snapshot(for: inputURL)

--- a/Tests/XCStringsToolTests/GenerateTests.swift
+++ b/Tests/XCStringsToolTests/GenerateTests.swift
@@ -4,7 +4,7 @@ import SnapshotTesting
 import XCTest
 
 final class GenerateTests: FixtureTestCase {
-    func testGenerate() throws {
+  @MainActor func testGenerate() throws {
         try eachFixture { inputURL in
             if !inputURL.lastPathComponent.hasPrefix("!") {
                 try snapshot(for: inputURL)
@@ -79,7 +79,7 @@ private extension GenerateTests {
     func assertError(
         for inputURL: URL,
         localizedDescription expected: String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertThrowsError(try run(for: inputURL), file: file, line: line) { error in
@@ -106,6 +106,7 @@ private extension GenerateTests {
 
         // Cleanup any temporary output
         addTeardownBlock {
+            let fileManager = FileManager.default /// Needed because `FileManager` is not `Sendable`
             if fileManager.fileExists(atPath: outputURL.path()) {
                 try? fileManager.removeItem(at: outputURL)
             }

--- a/Tests/XCStringsToolTests/GenerateTests.swift
+++ b/Tests/XCStringsToolTests/GenerateTests.swift
@@ -139,5 +139,7 @@ extension URL {
 
 extension Snapshotting where Value == String, Format == String {
     /// A snapshot strategy for comparing Swift Source Code based on equality.
-    public static let sourceCode = Snapshotting(pathExtension: "swift", diffing: .lines)
+    public static var sourceCode: Snapshotting<String, String> {
+        Snapshotting(pathExtension: "swift", diffing: .lines)
+    }
 }

--- a/Tests/XCStringsToolTests/GenerateTests.swift
+++ b/Tests/XCStringsToolTests/GenerateTests.swift
@@ -4,7 +4,7 @@ import SnapshotTesting
 import XCTest
 
 final class GenerateTests: FixtureTestCase {
-  @MainActor func testGenerate() throws {
+    @MainActor func testGenerate() throws {
         try eachFixture { inputURL in
             if !inputURL.lastPathComponent.hasPrefix("!") {
                 try snapshot(for: inputURL)


### PR DESCRIPTION
- Enabled upcoming/experimental swift feature flags
- Fixed most of the new warnings

Remaining are:
```
XCStringsTool
/Sources/StringExtractor/StringParser.swift
/Sources/StringExtractor/StringParser.swift:62:16 Static property 'regex' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6

PluginTests
/DerivedData/xcstrings-tool-dmlhbkyuqhmcebaijwuzkgpsrtoy/SourcePackages/plugins/xcstrings-tool.output/PluginTests/XCStringsToolPlugin/XCStringsTool/FeatureOne.swift
/DerivedData/xcstrings-tool-dmlhbkyuqhmcebaijwuzkgpsrtoy/SourcePackages/plugins/xcstrings-tool.output/PluginTests/XCStringsToolPlugin/XCStringsTool/FeatureOne.swift:224:170 Static property 'featureOne' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6

/DerivedData/xcstrings-tool-dmlhbkyuqhmcebaijwuzkgpsrtoy/SourcePackages/plugins/xcstrings-tool.output/PluginTests/XCStringsToolPlugin/XCStringsTool/Localizable.swift
/DerivedData/xcstrings-tool-dmlhbkyuqhmcebaijwuzkgpsrtoy/SourcePackages/plugins/xcstrings-tool.output/PluginTests/XCStringsToolPlugin/XCStringsTool/Localizable.swift:260:171 Static property 'localizable' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6

XCStringsToolTests
/Tests/XCStringsToolTests/GenerateTests.swift
/Tests/XCStringsToolTests/GenerateTests.swift:141:23 Static property 'sourceCode' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6

/DerivedData/xcstrings-tool-dmlhbkyuqhmcebaijwuzkgpsrtoy/SourcePackages/checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/String.swift
/DerivedData/xcstrings-tool-dmlhbkyuqhmcebaijwuzkgpsrtoy/SourcePackages/checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/String.swift:11:21 Static property 'lines' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6
```