### PR TITLE
Remove deployment target specifications for non-macOS platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,12 +7,7 @@ import PackageDescription
 let package = Package(
     name: "XCStringsTool",
     platforms: [
-        .macOS(.v13),
-        .iOS(.v16),
-        .tvOS(.v16),
-        .watchOS(.v9),
-        .macCatalyst(.v16),
-        .visionOS(.v1)
+        .macOS(.v13)
     ],
     products: [
         .executable(name: "xcstrings-tool", targets: ["xcstrings-tool"]),


### PR DESCRIPTION
If you use the xcstrings-tool repo (this one) directly so that you compile the CLI from source, it had previously been restricted to iOS/tvOS 16 and watchOS 9 despite the plugin generating code that was compatible with earlier OS versions.

It turns out that because the CLI, and even the build tool plugin are executed on the host build machine, we didn't actually need to specify deployment targets for other platforms, and by doing so, it was needlessly restricting us.

This PR removes those definitions so that if you prefer to use the plugin from source, you can. As long as you use macOS 13 or later.

<img width="1002" alt="Screenshot 2024-05-29 at 23 28 34" src="https://github.com/liamnichols/xcstrings-tool/assets/482871/83a9c50b-dccd-499b-afa9-33421d2fbaf4">
<img width="709" alt="Screenshot 2024-05-29 at 23 28 42" src="https://github.com/liamnichols/xcstrings-tool/assets/482871/cc29e414-9cb7-411b-98de-b3d674c80485">
