### PR TITLE
Add deprecation warnings to generated `LocalizedStringResource` API

### DIFF
--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/LocalizedStringResourceStringsTableComputedPropertySnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/LocalizedStringResourceStringsTableComputedPropertySnippet.swift
@@ -37,11 +37,7 @@ extension LocalizedStringResourceStringsTableComputedPropertySnippet: Snippet {
 
     @AttributeListBuilder
     var attributes: AttributeListSyntax {
-        AttributeSyntax(.identifier("iOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("macOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("tvOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("watchOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("visionOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.binaryOperator("*"), deprecated: nil, message: deprecationMessage)
     }
 
     @DeclModifierListBuilder

--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableResourceFunctionSnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableResourceFunctionSnippet.swift
@@ -35,11 +35,7 @@ struct LocalizedStringResourceStringsTableResourceFunctionSnippet: Snippet {
 
     @AttributeListBuilder
     var attributes: AttributeListSyntax {
-        AttributeSyntax(.identifier("iOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("macOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("tvOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("watchOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("visionOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.binaryOperator("*"), deprecated: nil, message: deprecationMessage)
     }
 
     @DeclModifierListBuilder

--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableResourceVariableSnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableResourceVariableSnippet.swift
@@ -35,11 +35,7 @@ struct LocalizedStringResourceStringsTableResourceVariableSnippet: Snippet {
 
     @AttributeListBuilder
     var attributes: AttributeListSyntax {
-        AttributeSyntax(.identifier("iOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("macOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("tvOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("watchOS"), deprecated: 100000, message: deprecationMessage)
-        AttributeSyntax(.identifier("visionOS"), deprecated: 100000, message: deprecationMessage)
+        AttributeSyntax(.binaryOperator("*"), deprecated: nil, message: deprecationMessage)
     }
 
     @DeclModifierListBuilder

--- a/Tests/PluginTests/PluginTests.swift
+++ b/Tests/PluginTests/PluginTests.swift
@@ -5,16 +5,12 @@ import XCTest
 final class PluginTests: XCTestCase {
     func testPluginGeneratedSources() {
         XCTAssertEqual(
-            String(localized: .localizable.demoBasic),
-            "A basic string"
-        )
-        XCTAssertEqual(
             String(localizable: .demoBasic),
             "A basic string"
         )
 
         XCTAssertEqual(
-            String(localized: .localizable.multiline(2)),
+            String(localized: .localizable(.multiline(2))),
             """
             A string that
             spans 2 lines
@@ -29,7 +25,7 @@ final class PluginTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            String(localized: .featureOne.pluralExample(1)),
+            String(localized: .featureOne(.pluralExample(1))),
             "1 string remaining"
         )
         XCTAssertEqual(
@@ -38,7 +34,7 @@ final class PluginTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            String(localized: .featureOne.pluralExample(10)),
+            String(localized: .featureOne(.pluralExample(10))),
             "10 strings remaining"
         )
         XCTAssertEqual(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -415,11 +415,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %@
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
         internal func at(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .at(arg1))
         }
@@ -431,11 +427,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %d
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
         internal func d(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d(arg1))
         }
@@ -447,11 +439,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %lld
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
         internal func d_length(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d_length(arg1))
         }
@@ -463,11 +451,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %f
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
         internal func f(_ arg1: Double) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .f(arg1))
         }
@@ -479,11 +463,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %.2f
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
         internal func f_precision(_ arg1: Double) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .f_precision(arg1))
         }
@@ -495,11 +475,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %i
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
         internal func i(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .i(arg1))
         }
@@ -511,11 +487,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %o
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
         internal func o(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .o(arg1))
         }
@@ -527,11 +499,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
         internal var percentage: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage)
         }
@@ -543,11 +511,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %%
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
         internal var percentage_escaped: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_escaped)
         }
@@ -559,11 +523,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test 50%% off
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
         internal var percentage_escaped_space_o: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_escaped_space_o)
         }
@@ -575,11 +535,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test 50% off
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
         internal var percentage_space_o: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_space_o)
         }
@@ -591,11 +547,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %u
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
         internal func u(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .u(arg1))
         }
@@ -607,21 +559,13 @@ extension LocalizedStringResource {
         /// ```
         /// Test %x
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
         internal func x(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .x(arg1))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.") internal static let formatSpecifiers = FormatSpecifiers()
+    @available (*, deprecated, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.") internal static let formatSpecifiers = FormatSpecifiers()
 
     internal init(formatSpecifiers: String.FormatSpecifiers) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -268,11 +268,7 @@ extension LocalizedStringResource {
         /// ```
         /// Continue
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
         internal var `continue`: LocalizedStringResource {
             LocalizedStringResource(localizable: .continue)
         }
@@ -284,11 +280,7 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         internal var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -298,11 +290,7 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         internal var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -312,11 +300,7 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         internal func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -326,21 +310,13 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         internal func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") internal static let localizable = Localizable()
+    @available (*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") internal static let localizable = Localizable()
 
     internal init(localizable: String.Localizable) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -215,21 +215,13 @@ extension LocalizedStringResource {
         /// - Two
         /// - Three
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
         internal var multiline: LocalizedStringResource {
             LocalizedStringResource(multiline: .multiline)
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.") internal static let multiline = Multiline()
+    @available (*, deprecated, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.") internal static let multiline = Multiline()
 
     internal init(multiline: String.Multiline) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -244,11 +244,7 @@ extension LocalizedStringResource {
         /// ```
         /// Second: %2$@ - First: %1$lld
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
         internal func reorder(_ arg1: Int, _ arg2: String) -> LocalizedStringResource {
             LocalizedStringResource(positional: .reorder(arg1, arg2))
         }
@@ -260,11 +256,7 @@ extension LocalizedStringResource {
         /// ```
         /// %1$lld, I repeat: %1$lld
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
         internal func repeatExplicit(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(positional: .repeatExplicit(arg1))
         }
@@ -276,21 +268,13 @@ extension LocalizedStringResource {
         /// ```
         /// %@, are you there? %1$@?
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
         internal func repeatImplicit(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(positional: .repeatImplicit(arg1))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.") internal static let positional = Positional()
+    @available (*, deprecated, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.") internal static let positional = Positional()
 
     internal init(positional: String.Positional) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -205,21 +205,13 @@ extension LocalizedStringResource {
         /// ```
         /// My Value
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
         internal var simpleKey: LocalizedStringResource {
             LocalizedStringResource(simple: .simpleKey)
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.") internal static let simple = Simple()
+    @available (*, deprecated, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.") internal static let simple = Simple()
 
     internal init(simple: String.Simple) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -209,21 +209,13 @@ extension LocalizedStringResource {
         /// ```
         /// %@! There are %lld strings and you have %lld remaining
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
         internal func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> LocalizedStringResource {
             LocalizedStringResource(substitution: .substitutions_exampleString(arg1, totalStrings: arg2, remainingStrings: arg3))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.") internal static let substitution = Substitution()
+    @available (*, deprecated, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.") internal static let substitution = Substitution()
 
     internal init(substitution: String.Substitution) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -221,11 +221,7 @@ extension LocalizedStringResource {
         /// ```
         /// Tap to open
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
         internal var stringDevice: LocalizedStringResource {
             LocalizedStringResource(variations: .stringDevice)
         }
@@ -235,21 +231,13 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld strings
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
         internal func stringPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(variations: .stringPlural(arg1))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.") internal static let variations = Variations()
+    @available (*, deprecated, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.") internal static let variations = Variations()
 
     internal init(variations: String.Variations) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
@@ -284,11 +284,7 @@ extension LocalizedStringResource {
         /// ```
         /// This is a simple string
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
         internal var key1: LocalizedStringResource {
             LocalizedStringResource(legacy: .key1)
         }
@@ -298,11 +294,7 @@ extension LocalizedStringResource {
         /// ```
         /// This string contains %lld integer
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
         internal func key2(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key2(arg1))
         }
@@ -312,11 +304,7 @@ extension LocalizedStringResource {
         /// ```
         /// Hello %@! This string %lld arguments
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
         internal func key3(_ arg1: String, _ arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key3(arg1, arg2))
         }
@@ -326,11 +314,7 @@ extension LocalizedStringResource {
         /// ```
         /// Second: %2$@, First: %1$@, First: %@
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
         internal func key4(_ arg1: String, _ arg2: String) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key4(arg1, arg2))
         }
@@ -340,11 +324,7 @@ extension LocalizedStringResource {
         /// ```
         /// First: %@, First: %1$@
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
         internal func key5(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key5(arg1))
         }
@@ -354,21 +334,13 @@ extension LocalizedStringResource {
         /// ```
         /// Hello %@, I have %lld plurals
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
         internal func key6(_ arg1: String, _ arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key6(arg1, arg2))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
+    @available (*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
 
     internal init(legacy: String.Legacy) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
@@ -267,11 +267,7 @@ extension LocalizedStringResource {
         /// ```
         /// This is a simple string
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
         internal var key1: LocalizedStringResource {
             LocalizedStringResource(legacy: .key1)
         }
@@ -281,11 +277,7 @@ extension LocalizedStringResource {
         /// ```
         /// This string contains %lld integer
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
         internal func key2(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key2(arg1))
         }
@@ -295,11 +287,7 @@ extension LocalizedStringResource {
         /// ```
         /// Hello %@! This string %lld arguments
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
         internal func key3(_ arg1: String, _ arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key3(arg1, arg2))
         }
@@ -309,11 +297,7 @@ extension LocalizedStringResource {
         /// ```
         /// Second: %2$@, First: %1$@, First: %@
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
         internal func key4(_ arg1: String, _ arg2: String) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key4(arg1, arg2))
         }
@@ -323,21 +307,13 @@ extension LocalizedStringResource {
         /// ```
         /// First: %@, First: %1$@
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
         internal func key5(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key5(arg1))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
+    @available (*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
 
     internal init(legacy: String.Legacy) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
@@ -204,21 +204,13 @@ extension LocalizedStringResource {
         /// ```
         /// Hello %@, I have %lld plurals
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
         internal func key6(_ arg1: String, _ arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key6(arg1, arg2))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
+    @available (*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
 
     internal init(legacy: String.Legacy) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -268,11 +268,7 @@ extension LocalizedStringResource {
         /// ```
         /// Continue
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
         package var `continue`: LocalizedStringResource {
             LocalizedStringResource(localizable: .continue)
         }
@@ -284,11 +280,7 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         package var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -298,11 +290,7 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         package var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -312,11 +300,7 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         package func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -326,21 +310,13 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         package func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") package static let localizable = Localizable()
+    @available (*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") package static let localizable = Localizable()
 
     package init(localizable: String.Localizable) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -268,11 +268,7 @@ extension LocalizedStringResource {
         /// ```
         /// Continue
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
         public var `continue`: LocalizedStringResource {
             LocalizedStringResource(localizable: .continue)
         }
@@ -284,11 +280,7 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         public var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -298,11 +290,7 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         public var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -312,11 +300,7 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         public func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -326,21 +310,13 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
-        @available (iOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (macOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (tvOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (watchOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
-        @available (visionOS, deprecated: 100000, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available (*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         public func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    @available (iOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (macOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (tvOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (watchOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.")
-    @available (visionOS, deprecated: 100000, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") public static let localizable = Localizable()
+    @available (*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") public static let localizable = Localizable()
 
     public init(localizable: String.Localizable) {
         self.init(


### PR DESCRIPTION
In 0.4.0, we introduced `LocalizedStringResource.localized(_:)` to match the same method added to `LocalizedStringKey` and as a result, we deprecated the original generated code on the `LocalizedStringResource` type.

In 0.4.0 however, a warning was not omitted. In 0.5.0, I am now omitting a warning because this code will be removed from an upcoming release:

<img width="1223" alt="Screenshot 2024-06-09 at 13 38 15" src="https://github.com/liamnichols/xcstrings-tool/assets/482871/e5dc9a5d-b44c-4dc1-83b5-45dd29b5f915">

Please see the following from the 0.4.0 release notes:

> It is now preferred to use the `LocalizedStringKey.localizable(_:)` or `LocalizedStringResource.localizable(_:)` static methods instead of the `LocalizedStringResource.localizable` static property. The static property has been marked as deprecated. A warning will be emitted starting in 0.5.0 and the code will be completely removed in 1.0.0. See below for migrating your code:
> 
> ```diff
> - Text(.localizable.foo)
> + Text(.localizable(.foo))
> ```
> 
> ```diff
> - String(localized: .localizable.bar)
> + String(localizable: .bar)
> ```
> 
> ```diff
> - .navigationTitle("\(.localizable.title)")
> + .navigationTitle(.localizable(.title))
> ```