### PR TITLE
Improve performance when generating source code for large Strings Catalogs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,6 +32,8 @@ jobs:
       run: swift package --allow-writing-to-directory .benchmarkBaselines/ benchmark baseline update main
     - name: Compare Benchmarks
       run: |
+        set +e
+
         benchmarkDate="$(date)"
         benchmarkCheckOutput="$(swift package benchmark baseline check main pull_request --format markdown)"
         benchmarkExitStatus="$?"

--- a/Sources/StringGenerator/Extensions/Array+Position.swift
+++ b/Sources/StringGenerator/Extensions/Array+Position.swift
@@ -1,0 +1,21 @@
+extension Array {
+    struct Position {
+        let isFirst: Bool
+        let isLast: Bool
+        let index: Int
+    }
+
+    var withPosition: some Collection<(Position, Element)> {
+        zip(indices, self)
+            .lazy
+            .map { (index, element) in
+                let position = Position(
+                    isFirst: index == indices.first,
+                    isLast: index == indices.last,
+                    index: index
+                )
+
+                return (position, element)
+            }
+    }
+}

--- a/Sources/StringGenerator/Extensions/StructDeclSyntax.swift
+++ b/Sources/StringGenerator/Extensions/StructDeclSyntax.swift
@@ -1,9 +1,0 @@
-import SwiftSyntax
-
-extension StructDeclSyntax {
-    func spacingMembers(_ lineCount: Int = 2) -> StructDeclSyntax {
-        updating(\.memberBlock) { memberBlock in
-            memberBlock = memberBlock.spacingMembers(lineCount)
-        }
-    }
-}

--- a/Sources/StringGenerator/Extensions/SyntaxProtocol.swift
+++ b/Sources/StringGenerator/Extensions/SyntaxProtocol.swift
@@ -7,4 +7,11 @@ public extension SyntaxProtocol {
         changes(&copy[keyPath: keyPath])
         return copy
     }
+
+    /// Returns a new syntax node that has the child at `keyPath` replaced by
+    /// `value` if the given condition is met
+    func with<T>(_ keyPath: WritableKeyPath<Self, T>, _ value: T, if condition: Bool) -> Self {
+        guard condition else { return self }
+        return with(keyPath, value)
+    }
 }

--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableStructSnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableStructSnippet.swift
@@ -12,15 +12,17 @@ extension LocalizedStringResourceStringsTableStructSnippet: Snippet {
             modifiers: modifiers,
             name: stringsTable.type
         ) {
-            for accessor in stringsTable.accessors {
-                if accessor.hasArguments {
-                    LocalizedStringResourceStringsTableResourceFunctionSnippet(accessor: accessor)
-                } else {
-                    LocalizedStringResourceStringsTableResourceVariableSnippet(accessor: accessor)
+            for (position, accessor) in stringsTable.accessors.withPosition {
+                MemberBlockItemListSyntax {
+                    if accessor.hasArguments {
+                        LocalizedStringResourceStringsTableResourceFunctionSnippet(accessor: accessor)
+                    } else {
+                        LocalizedStringResourceStringsTableResourceVariableSnippet(accessor: accessor)
+                    }
                 }
+                .with(\.trailingTrivia, .newlines(2), if: !position.isLast)
             }
         }
-        .spacingMembers()
     }
 
     var leadingTrivia: Trivia? {

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
@@ -75,16 +75,16 @@ struct StringStringsTableStructSnippet: Snippet {
             }
             .with(\.trailingTrivia, .newlines(2))
 
-            MemberBlockItemListSyntax {
-                for accessor in stringsTable.accessors {
+            for accessor in stringsTable.accessors {
+                MemberBlockItemListSyntax {
                     if accessor.hasArguments {
                         StringStringsTableResourceFunctionSnippet(accessor: accessor)
                     } else {
                         StringStringsTableResourceVariableSnippet(accessor: accessor)
                     }
                 }
+                .with(\.trailingTrivia, .newlines(2))
             }
-            .map { $0.with(\.trailingTrivia, .newlines(2)) }
 
             // @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
             // fileprivate var defaultValue: String.LocalizedValue { ... }


### PR DESCRIPTION
I profiled the project recently and realised that we were iterating over the accessors, then mapping all of them after just to add two lines of spacing.

We can save a good chunk of time if we don't map and we don't iterate through the whole array again and instead if we just add the spacing in the first loop.
