### PR TITLE
Support Swift 6 language mode and Swift Syntax 600.0.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,10 @@ jobs:
     - name: Benchmark Pull Request
       run: swift package --allow-writing-to-directory .benchmarkBaselines/ benchmark baseline update pull_request
     - name: Switch Branches
-      run: git checkout main
+      run: |
+        git stash
+        git checkout main
+        git stash pop
     - name: Benchmark Main
       run: swift package --allow-writing-to-directory .benchmarkBaselines/ benchmark baseline update main
     - name: Compare Benchmarks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Validate SPI Manifest
     runs-on: macos-14
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
       VALIDATE_SPI_MANIFEST: YES
     steps:
     - name: Checkout Repo
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Compile Snapshots
       run: .github/scripts/compile-snapshots.sh
-  unit-test:
+  unit-test-xcode:
     name: Unit Tests (Xcode ${{ matrix.xcode }})
     strategy:
       fail-fast: false
@@ -48,6 +48,25 @@ jobs:
     runs-on: ${{ matrix.macos }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+    - name: Run Tests
+      run: xcodebuild clean test -scheme XCStringsTool-Package -destination platform=macOS
+  unit-test-swift-syntax:
+    name: Unit Tests (Swift Syntax ${{ matrix.swift-syntax }})
+    strategy:
+      fail-fast: false
+      matrix:
+        swift-syntax:
+        - "509.0.2"
+        - "509.1.1"
+        - "510.0.2"
+        - "600.0.0-prerelease-2024-06-04"
+    runs-on: macOS-14
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+      SWIFT_SYNTAX_VERSION: ${{ matrix.swift-syntax }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,14 +59,23 @@ jobs:
       fail-fast: false
       matrix:
         swift-syntax:
-        - 6ad4ea24b01559dde0773e3d091f1b9e36175036 # 509.0.2
-        - 64889f0c732f210a935a0ad7cda38f77f876262d # 509.1.1
-        - 303e5c5c36d6a558407d364878df131c3546fad8 # 510.0.2
-        - 4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c # 600.0.0-prerelease-2024-06-12
+        - "509.0.2"
+        - "509.1.1"
+        - "510.0.2"
+        - "600.0.0-prerelease-2024-06-12"
+        include:
+        - swift-syntax: "509.0.2"
+          revision: 6ad4ea24b01559dde0773e3d091f1b9e36175036
+        - swift-syntax: "509.1.1"
+          revision: 64889f0c732f210a935a0ad7cda38f77f876262d
+        - swift-syntax: "510.0.2"
+          revision: 303e5c5c36d6a558407d364878df131c3546fad8
+        - swift-syntax: "600.0.0-prerelease-2024-06-12"
+          revision: 4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c
     runs-on: macOS-14
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
-      SWIFT_SYNTAX_REVISION: ${{ matrix.swift-syntax }}
+      SWIFT_SYNTAX_REVISION: ${{ matrix.revision }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,14 +59,14 @@ jobs:
       fail-fast: false
       matrix:
         swift-syntax:
-        - "509.0.2"
-        - "509.1.1"
-        - "510.0.2"
-        - "600.0.0-prerelease-2024-06-04"
+        - 6ad4ea24b01559dde0773e3d091f1b9e36175036 # 509.0.2
+        - 64889f0c732f210a935a0ad7cda38f77f876262d # 509.1.1
+        - 303e5c5c36d6a558407d364878df131c3546fad8 # 510.0.2
+        - 4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c # 600.0.0-prerelease-2024-06-12
     runs-on: macOS-14
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
-      SWIFT_SYNTAX_VERSION: ${{ matrix.swift-syntax }}
+      SWIFT_SYNTAX_REVISION: ${{ matrix.swift-syntax }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
-        "version" : "1.16.0"
+        "revision" : "8ddd519780452729c6634ad6bd0d2595938e9ea3",
+        "version" : "1.16.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -4,12 +4,6 @@
 import Foundation
 import PackageDescription
 
-let swiftSyntax: Package.Dependency = if let revision = ProcessInfo.processInfo.environment["SWIFT_SYNTAX_REVISION"] {
-    .package(url: "https://github.com/apple/swift-syntax.git", revision: revision)
-} else {
-    .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0" ..< "601.0.0")
-}
-
 let package = Package(
     name: "XCStringsTool",
     defaultLocalization: "en",
@@ -22,8 +16,8 @@ let package = Package(
         .library(name: "StringCatalog", targets: ["StringCatalog"])
     ],
     dependencies: [
-        swiftSyntax,
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
+        .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0" ..< "601.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.13.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
     ],
@@ -171,5 +165,14 @@ if ProcessInfo.processInfo.environment.keys.contains("BENCHMARK_PACKAGE") {
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
             ]
         )
+    )
+}
+
+// Support testing different versions of Swift Syntax
+if let revision = ProcessInfo.processInfo.environment["SWIFT_SYNTAX_REVISION"] {
+    // TODO: The `kind` symbol isn't available in Xcode 15.2? Check newer versions.
+    package.dependencies.removeAll(where: { $0.url == "https://github.com/apple/swift-syntax.git" })
+    package.dependencies.append(
+        .package(url: "https://github.com/apple/swift-syntax.git", revision: revision)
     )
 }

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,13 @@
 import Foundation
 import PackageDescription
 
+let swiftSyntaxVersion = ProcessInfo.processInfo.environment["SWIFT_SYNTAX_VERSION"].flatMap(Version.init(_:))
+let swiftSyntax: Package.Dependency = if let version = swiftSyntaxVersion {
+    .package(url: "https://github.com/apple/swift-syntax.git", exact: version)
+} else {
+    .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0" ..< "601.0.0")
+}
+
 let package = Package(
     name: "XCStringsTool",
     defaultLocalization: "en",
@@ -17,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
-        .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0" ..< "601.0.0"),
+        swiftSyntax,
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.13.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
-        .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0" ..< "511.0.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0" ..< "601.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.13.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,9 @@ let package = Package(
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
                 .target(name: "XCStringsToolConstants")
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("BareSlashRegexLiterals")
             ]
         ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,8 @@
 import Foundation
 import PackageDescription
 
-let swiftSyntaxVersion = ProcessInfo.processInfo.environment["SWIFT_SYNTAX_VERSION"].flatMap(Version.init(_:))
-let swiftSyntax: Package.Dependency = if let version = swiftSyntaxVersion {
-    .package(url: "https://github.com/apple/swift-syntax.git", exact: version)
+let swiftSyntax: Package.Dependency = if let revision = ProcessInfo.processInfo.environment["SWIFT_SYNTAX_REVISION"] {
+    .package(url: "https://github.com/apple/swift-syntax.git", revision: revision)
 } else {
     .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0" ..< "601.0.0")
 }
@@ -23,8 +22,8 @@ let package = Package(
         .library(name: "StringCatalog", targets: ["StringCatalog"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
         swiftSyntax,
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.13.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
     ],

--- a/Sources/StringGenerator/Extensions/String+BacktickIfNeeded.swift
+++ b/Sources/StringGenerator/Extensions/String+BacktickIfNeeded.swift
@@ -10,6 +10,9 @@ extension String {
     }
 
     private var _isValidVariableName: Bool {
+#if canImport(SwiftSyntax600)
+        isValidSwiftIdentifier(for: .variableName)
+#else
         let name = self
 
         var parser = Parser("var \(name)")
@@ -41,5 +44,6 @@ extension String {
         }
 
         return true
+#endif
     }
 }

--- a/Sources/StringGenerator/Snippets/IfCanImportSnippet.swift
+++ b/Sources/StringGenerator/Snippets/IfCanImportSnippet.swift
@@ -21,10 +21,16 @@ extension IfCanImportSnippet: Snippet {
             clauses: IfConfigClauseListSyntax {
                 IfConfigClauseSyntax(
                     poundKeyword: .poundIfToken(),
-                    condition: CanImportExprSyntax(importPath: .module(module)),
+                    condition: condition,
                     elements: .statements(items)
                 )
             }
         )
+    }
+
+    var condition: some ExprSyntaxProtocol {
+        FunctionCallExprSyntax(callee: DeclReferenceExprSyntax(baseName: "canImport")) {
+            LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: .module(.SwiftUI)))
+        }
     }
 }

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -29,32 +29,11 @@ public struct StringGenerator {
 }
 
 private extension String {
-    #if !canImport(SwiftSyntax600)
-    static let prefix = Reference<Substring>()
-    static let suffix = Reference<Substring>()
-
-    static let regex = Regex {
-        Capture(as: prefix) {
-            ChoiceOf {
-                Regex {
-                    One(.anyOf("#@"))
-                    "available"
-                }
-                "#if canImport"
-            }
-        }
-        One(.whitespace)
-        Capture(as: suffix) {
-            "("
-        }
-    }
-    #endif
-
     // https://github.com/liamnichols/xcstrings-tool/issues/97
     func patchingSwift6CompatibilityIssuesIfNeeded() -> String {
         #if !canImport(SwiftSyntax600)
-        replacing(Self.regex, with: { match in
-            match[Self.prefix] + match[Self.suffix]
+        replacing(/[#@]available\s\(/, with: { match in
+            match.output.filter { !$0.isWhitespace }
         })
         #else
         self

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -31,7 +31,10 @@ private extension String {
     // https://github.com/liamnichols/xcstrings-tool/issues/97
     func patchingSwift6CompatibilityIssuesIfNeeded() -> String {
         #if !canImport(SwiftSyntax600)
-        replacingOccurrences(of: "@available (", with: "@available(")
+//        replacingOccurrences(of: "@available (", with: "@available(")
+        replacing(#/[#@]available\s\(/#, with: { match in
+            match.output.filter { !$0.isWhitespace }
+        })
         #else
         self
         #endif

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -23,5 +23,17 @@ public struct StringGenerator {
             .syntax
             .formatted()
             .description
+            .patchingSwift6CompatibilityIssuesIfNeeded()
+    }
+}
+
+private extension String {
+    // https://github.com/liamnichols/xcstrings-tool/issues/97
+    func patchingSwift6CompatibilityIssuesIfNeeded() -> String {
+        #if !canImport(SwiftSyntax600)
+        replacingOccurrences(of: "@available (", with: "@available(")
+        #else
+        self
+        #endif
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -582,7 +582,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -589,7 +589,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘FormatSpecifiers‘ strings table.
     internal init(formatSpecifiers: String.FormatSpecifiers) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(formatSpecifiers: formatSpecifiers))
             return
         }
@@ -625,7 +625,7 @@ extension LocalizedStringKey {
     internal init(formatSpecifiers: String.FormatSpecifiers) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(formatSpecifiers: formatSpecifiers))
         } else {
             stringInterpolation.appendInterpolation(Text(formatSpecifiers: formatSpecifiers))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -415,7 +415,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %@
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.at(_:)` instead. This method will be removed in the future.")
         internal func at(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .at(arg1))
         }
@@ -427,7 +427,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %d
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.d(_:)` instead. This method will be removed in the future.")
         internal func d(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d(arg1))
         }
@@ -439,7 +439,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %lld
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.d_length(_:)` instead. This method will be removed in the future.")
         internal func d_length(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .d_length(arg1))
         }
@@ -451,7 +451,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %f
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.f(_:)` instead. This method will be removed in the future.")
         internal func f(_ arg1: Double) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .f(arg1))
         }
@@ -463,7 +463,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %.2f
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.f_precision(_:)` instead. This method will be removed in the future.")
         internal func f_precision(_ arg1: Double) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .f_precision(arg1))
         }
@@ -475,7 +475,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %i
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.i(_:)` instead. This method will be removed in the future.")
         internal func i(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .i(arg1))
         }
@@ -487,7 +487,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %o
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.o(_:)` instead. This method will be removed in the future.")
         internal func o(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .o(arg1))
         }
@@ -499,7 +499,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.percentage` instead. This property will be removed in the future.")
         internal var percentage: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage)
         }
@@ -511,7 +511,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %%
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.percentage_escaped` instead. This property will be removed in the future.")
         internal var percentage_escaped: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_escaped)
         }
@@ -523,7 +523,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test 50%% off
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.percentage_escaped_space_o` instead. This property will be removed in the future.")
         internal var percentage_escaped_space_o: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_escaped_space_o)
         }
@@ -535,7 +535,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test 50% off
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.percentage_space_o` instead. This property will be removed in the future.")
         internal var percentage_space_o: LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .percentage_space_o)
         }
@@ -547,7 +547,7 @@ extension LocalizedStringResource {
         /// ```
         /// Test %u
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.u(_:)` instead. This method will be removed in the future.")
         internal func u(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .u(arg1))
         }
@@ -559,13 +559,13 @@ extension LocalizedStringResource {
         /// ```
         /// Test %x
         /// ```
-        @available (*, deprecated, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.FormatSpecifiers.x(_:)` instead. This method will be removed in the future.")
         internal func x(_ arg1: UInt) -> LocalizedStringResource {
             LocalizedStringResource(formatSpecifiers: .x(arg1))
         }
     }
 
-    @available (*, deprecated, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.") internal static let formatSpecifiers = FormatSpecifiers()
+    @available(*, deprecated, message: "Use the `formatSpecifiers(_:)` static method instead. This property will be removed in the future.") internal static let formatSpecifiers = FormatSpecifiers()
 
     internal init(formatSpecifiers: String.FormatSpecifiers) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -268,7 +268,7 @@ extension LocalizedStringResource {
         /// ```
         /// Continue
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
         internal var `continue`: LocalizedStringResource {
             LocalizedStringResource(localizable: .continue)
         }
@@ -280,7 +280,7 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         internal var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -290,7 +290,7 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         internal var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -300,7 +300,7 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         internal func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -310,13 +310,13 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         internal func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    @available (*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") internal static let localizable = Localizable()
+    @available(*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") internal static let localizable = Localizable()
 
     internal init(localizable: String.Localizable) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -333,7 +333,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -340,7 +340,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Localizable‘ strings table.
     internal init(localizable: String.Localizable) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(localizable: localizable))
             return
         }
@@ -376,7 +376,7 @@ extension LocalizedStringKey {
     internal init(localizable: String.Localizable) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(localizable: localizable))
         } else {
             stringInterpolation.appendInterpolation(Text(localizable: localizable))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -238,7 +238,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -215,13 +215,13 @@ extension LocalizedStringResource {
         /// - Two
         /// - Three
         /// ```
-        @available (*, deprecated, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Multiline.multiline` instead. This property will be removed in the future.")
         internal var multiline: LocalizedStringResource {
             LocalizedStringResource(multiline: .multiline)
         }
     }
 
-    @available (*, deprecated, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.") internal static let multiline = Multiline()
+    @available(*, deprecated, message: "Use the `multiline(_:)` static method instead. This property will be removed in the future.") internal static let multiline = Multiline()
 
     internal init(multiline: String.Multiline) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -245,7 +245,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Multiline‘ strings table.
     internal init(multiline: String.Multiline) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(multiline: multiline))
             return
         }
@@ -281,7 +281,7 @@ extension LocalizedStringKey {
     internal init(multiline: String.Multiline) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(multiline: multiline))
         } else {
             stringInterpolation.appendInterpolation(Text(multiline: multiline))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -291,7 +291,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -244,7 +244,7 @@ extension LocalizedStringResource {
         /// ```
         /// Second: %2$@ - First: %1$lld
         /// ```
-        @available (*, deprecated, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Positional.reorder(_:_:)` instead. This method will be removed in the future.")
         internal func reorder(_ arg1: Int, _ arg2: String) -> LocalizedStringResource {
             LocalizedStringResource(positional: .reorder(arg1, arg2))
         }
@@ -256,7 +256,7 @@ extension LocalizedStringResource {
         /// ```
         /// %1$lld, I repeat: %1$lld
         /// ```
-        @available (*, deprecated, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Positional.repeatExplicit(_:)` instead. This method will be removed in the future.")
         internal func repeatExplicit(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(positional: .repeatExplicit(arg1))
         }
@@ -268,13 +268,13 @@ extension LocalizedStringResource {
         /// ```
         /// %@, are you there? %1$@?
         /// ```
-        @available (*, deprecated, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Positional.repeatImplicit(_:)` instead. This method will be removed in the future.")
         internal func repeatImplicit(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(positional: .repeatImplicit(arg1))
         }
     }
 
-    @available (*, deprecated, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.") internal static let positional = Positional()
+    @available(*, deprecated, message: "Use the `positional(_:)` static method instead. This property will be removed in the future.") internal static let positional = Positional()
 
     internal init(positional: String.Positional) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -298,7 +298,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Positional‘ strings table.
     internal init(positional: String.Positional) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(positional: positional))
             return
         }
@@ -334,7 +334,7 @@ extension LocalizedStringKey {
     internal init(positional: String.Positional) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(positional: positional))
         } else {
             stringInterpolation.appendInterpolation(Text(positional: positional))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -205,13 +205,13 @@ extension LocalizedStringResource {
         /// ```
         /// My Value
         /// ```
-        @available (*, deprecated, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Simple.simpleKey` instead. This property will be removed in the future.")
         internal var simpleKey: LocalizedStringResource {
             LocalizedStringResource(simple: .simpleKey)
         }
     }
 
-    @available (*, deprecated, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.") internal static let simple = Simple()
+    @available(*, deprecated, message: "Use the `simple(_:)` static method instead. This property will be removed in the future.") internal static let simple = Simple()
 
     internal init(simple: String.Simple) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -228,7 +228,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -235,7 +235,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Simple‘ strings table.
     internal init(simple: String.Simple) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(simple: simple))
             return
         }
@@ -271,7 +271,7 @@ extension LocalizedStringKey {
     internal init(simple: String.Simple) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(simple: simple))
         } else {
             stringInterpolation.appendInterpolation(Text(simple: simple))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -232,7 +232,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -239,7 +239,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Substitution‘ strings table.
     internal init(substitution: String.Substitution) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(substitution: substitution))
             return
         }
@@ -275,7 +275,7 @@ extension LocalizedStringKey {
     internal init(substitution: String.Substitution) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(substitution: substitution))
         } else {
             stringInterpolation.appendInterpolation(Text(substitution: substitution))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -209,13 +209,13 @@ extension LocalizedStringResource {
         /// ```
         /// %@! There are %lld strings and you have %lld remaining
         /// ```
-        @available (*, deprecated, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Substitution.substitutions_exampleString(_:totalStrings:remainingStrings:)` instead. This method will be removed in the future.")
         internal func substitutions_exampleString(_ arg1: String, totalStrings arg2: Int, remainingStrings arg3: Int) -> LocalizedStringResource {
             LocalizedStringResource(substitution: .substitutions_exampleString(arg1, totalStrings: arg2, remainingStrings: arg3))
         }
     }
 
-    @available (*, deprecated, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.") internal static let substitution = Substitution()
+    @available(*, deprecated, message: "Use the `substitution(_:)` static method instead. This property will be removed in the future.") internal static let substitution = Substitution()
 
     internal init(substitution: String.Substitution) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -254,7 +254,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -261,7 +261,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Variations‘ strings table.
     internal init(variations: String.Variations) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(variations: variations))
             return
         }
@@ -297,7 +297,7 @@ extension LocalizedStringKey {
     internal init(variations: String.Variations) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(variations: variations))
         } else {
             stringInterpolation.appendInterpolation(Text(variations: variations))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -221,7 +221,7 @@ extension LocalizedStringResource {
         /// ```
         /// Tap to open
         /// ```
-        @available (*, deprecated, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Variations.stringDevice` instead. This property will be removed in the future.")
         internal var stringDevice: LocalizedStringResource {
             LocalizedStringResource(variations: .stringDevice)
         }
@@ -231,13 +231,13 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld strings
         /// ```
-        @available (*, deprecated, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Variations.stringPlural(_:)` instead. This method will be removed in the future.")
         internal func stringPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(variations: .stringPlural(arg1))
         }
     }
 
-    @available (*, deprecated, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.") internal static let variations = Variations()
+    @available(*, deprecated, message: "Use the `variations(_:)` static method instead. This property will be removed in the future.") internal static let variations = Variations()
 
     internal init(variations: String.Variations) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
@@ -284,7 +284,7 @@ extension LocalizedStringResource {
         /// ```
         /// This is a simple string
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
         internal var key1: LocalizedStringResource {
             LocalizedStringResource(legacy: .key1)
         }
@@ -294,7 +294,7 @@ extension LocalizedStringResource {
         /// ```
         /// This string contains %lld integer
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
         internal func key2(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key2(arg1))
         }
@@ -304,7 +304,7 @@ extension LocalizedStringResource {
         /// ```
         /// Hello %@! This string %lld arguments
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
         internal func key3(_ arg1: String, _ arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key3(arg1, arg2))
         }
@@ -314,7 +314,7 @@ extension LocalizedStringResource {
         /// ```
         /// Second: %2$@, First: %1$@, First: %@
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
         internal func key4(_ arg1: String, _ arg2: String) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key4(arg1, arg2))
         }
@@ -324,7 +324,7 @@ extension LocalizedStringResource {
         /// ```
         /// First: %@, First: %1$@
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
         internal func key5(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key5(arg1))
         }
@@ -334,13 +334,13 @@ extension LocalizedStringResource {
         /// ```
         /// Hello %@, I have %lld plurals
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
         internal func key6(_ arg1: String, _ arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key6(arg1, arg2))
         }
     }
 
-    @available (*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
+    @available(*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
 
     internal init(legacy: String.Legacy) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
@@ -364,7 +364,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Legacy‘ strings table.
     internal init(legacy: String.Legacy) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(legacy: legacy))
             return
         }
@@ -400,7 +400,7 @@ extension LocalizedStringKey {
     internal init(legacy: String.Legacy) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(legacy: legacy))
         } else {
             stringInterpolation.appendInterpolation(Text(legacy: legacy))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
@@ -357,7 +357,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
@@ -267,7 +267,7 @@ extension LocalizedStringResource {
         /// ```
         /// This is a simple string
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key1` instead. This property will be removed in the future.")
         internal var key1: LocalizedStringResource {
             LocalizedStringResource(legacy: .key1)
         }
@@ -277,7 +277,7 @@ extension LocalizedStringResource {
         /// ```
         /// This string contains %lld integer
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key2(_:)` instead. This method will be removed in the future.")
         internal func key2(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key2(arg1))
         }
@@ -287,7 +287,7 @@ extension LocalizedStringResource {
         /// ```
         /// Hello %@! This string %lld arguments
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key3(_:_:)` instead. This method will be removed in the future.")
         internal func key3(_ arg1: String, _ arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key3(arg1, arg2))
         }
@@ -297,7 +297,7 @@ extension LocalizedStringResource {
         /// ```
         /// Second: %2$@, First: %1$@, First: %@
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key4(_:_:)` instead. This method will be removed in the future.")
         internal func key4(_ arg1: String, _ arg2: String) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key4(arg1, arg2))
         }
@@ -307,13 +307,13 @@ extension LocalizedStringResource {
         /// ```
         /// First: %@, First: %1$@
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key5(_:)` instead. This method will be removed in the future.")
         internal func key5(_ arg1: String) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key5(arg1))
         }
     }
 
-    @available (*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
+    @available(*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
 
     internal init(legacy: String.Legacy) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
@@ -337,7 +337,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Legacy‘ strings table.
     internal init(legacy: String.Legacy) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(legacy: legacy))
             return
         }
@@ -373,7 +373,7 @@ extension LocalizedStringKey {
     internal init(legacy: String.Legacy) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(legacy: legacy))
         } else {
             stringInterpolation.appendInterpolation(Text(legacy: legacy))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
@@ -330,7 +330,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
@@ -234,7 +234,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Legacy‘ strings table.
     internal init(legacy: String.Legacy) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(legacy: legacy))
             return
         }
@@ -270,7 +270,7 @@ extension LocalizedStringKey {
     internal init(legacy: String.Legacy) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(legacy: legacy))
         } else {
             stringInterpolation.appendInterpolation(Text(legacy: legacy))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
@@ -204,13 +204,13 @@ extension LocalizedStringResource {
         /// ```
         /// Hello %@, I have %lld plurals
         /// ```
-        @available (*, deprecated, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Legacy.key6(_:_:)` instead. This method will be removed in the future.")
         internal func key6(_ arg1: String, _ arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(legacy: .key6(arg1, arg2))
         }
     }
 
-    @available (*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
+    @available(*, deprecated, message: "Use the `legacy(_:)` static method instead. This property will be removed in the future.") internal static let legacy = Legacy()
 
     internal init(legacy: String.Legacy) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
@@ -227,7 +227,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -333,7 +333,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -268,7 +268,7 @@ extension LocalizedStringResource {
         /// ```
         /// Continue
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
         package var `continue`: LocalizedStringResource {
             LocalizedStringResource(localizable: .continue)
         }
@@ -280,7 +280,7 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         package var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -290,7 +290,7 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         package var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -300,7 +300,7 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         package func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -310,13 +310,13 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         package func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    @available (*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") package static let localizable = Localizable()
+    @available(*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") package static let localizable = Localizable()
 
     package init(localizable: String.Localizable) {
         self.init(

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -340,7 +340,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Localizable‘ strings table.
     package init(localizable: String.Localizable) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(localizable: localizable))
             return
         }
@@ -376,7 +376,7 @@ extension LocalizedStringKey {
     package init(localizable: String.Localizable) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(localizable: localizable))
         } else {
             stringInterpolation.appendInterpolation(Text(localizable: localizable))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -340,7 +340,7 @@ import SwiftUI
 extension Text {
     /// Creates a text view that displays a localized string defined in the ‘Localizable‘ strings table.
     public init(localizable: String.Localizable) {
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             self.init(LocalizedStringResource(localizable: localizable))
             return
         }
@@ -376,7 +376,7 @@ extension LocalizedStringKey {
     public init(localizable: String.Localizable) {
         var stringInterpolation = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 1)
 
-        if #available (macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             stringInterpolation.appendInterpolation(LocalizedStringResource(localizable: localizable))
         } else {
             stringInterpolation.appendInterpolation(Text(localizable: localizable))

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -333,7 +333,7 @@ extension LocalizedStringResource {
     }
 }
 
-#if canImport (SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(macOS 10.5, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -268,7 +268,7 @@ extension LocalizedStringResource {
         /// ```
         /// Continue
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.continue` instead. This property will be removed in the future.")
         public var `continue`: LocalizedStringResource {
             LocalizedStringResource(localizable: .continue)
         }
@@ -280,7 +280,7 @@ extension LocalizedStringResource {
         /// ```
         /// Default Value
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.key` instead. This property will be removed in the future.")
         public var key: LocalizedStringResource {
             LocalizedStringResource(localizable: .key)
         }
@@ -290,7 +290,7 @@ extension LocalizedStringResource {
         /// ```
         /// Multiplatform Original
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.myDeviceVariant` instead. This property will be removed in the future.")
         public var myDeviceVariant: LocalizedStringResource {
             LocalizedStringResource(localizable: .myDeviceVariant)
         }
@@ -300,7 +300,7 @@ extension LocalizedStringResource {
         /// ```
         /// I have %lld plurals
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.myPlural(_:)` instead. This method will be removed in the future.")
         public func myPlural(_ arg1: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .myPlural(arg1))
         }
@@ -310,13 +310,13 @@ extension LocalizedStringResource {
         /// ```
         /// %lld: People liked %lld posts
         /// ```
-        @available (*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
+        @available(*, deprecated, message: "Use `String.Localizable.mySubstitute(_:count:)` instead. This method will be removed in the future.")
         public func mySubstitute(_ arg1: Int, count arg2: Int) -> LocalizedStringResource {
             LocalizedStringResource(localizable: .mySubstitute(arg1, count: arg2))
         }
     }
 
-    @available (*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") public static let localizable = Localizable()
+    @available(*, deprecated, message: "Use the `localizable(_:)` static method instead. This property will be removed in the future.") public static let localizable = Localizable()
 
     public init(localizable: String.Localizable) {
         self.init(


### PR DESCRIPTION
- Closes https://github.com/liamnichols/xcstrings-tool/issues/97

Whitespace between `@available` and the opening `(` causes a compile failure in Swift 6. It was found in the generated code due to how Swift Syntax 5XX.X.X would format the output.

This Pull Request does the following:

- Patches the generated code with a simple regex find and replace
- Updates the Package.swift to support Swift Syntax 600.0.0 once it is released
- Adds CI checks to run against each major Swift Syntax version
- Removes the regex workaround when using Swift Syntax 600.0.0 since the formatter in this version fixes the original whitespace issue
- Fix some deprecation warnings and removes other workarounds when using Swift Syntax 600.0.0