### PR TITLE
Compile snapshots using Swift 6 Language Mode

### DIFF
--- a/.github/scripts/compile-snapshots.sh
+++ b/.github/scripts/compile-snapshots.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 
-echo "Swift Version:"
+echo "Toolchain:"
+echo "=========="
 xcrun swift --version
 echo ""
 
+vers=${SWIFT_VERSION:-5}
+echo "Swift Language Mode:"
+echo "===================="
+echo "Swift $vers"
+echo ""
+
+echo "Compiling Snapshots:"
+echo "===================="
 for snapshot in Tests/XCStringsToolTests/__Snapshots__/**/*.swift; do
   echo "Compiling ‘$(basename $snapshot)‘"
 
-  if xcrun swiftc "$snapshot" -package-name "MyPackage" -o /dev/null ; then
+  if xcrun swiftc "$snapshot" -package-name "MyPackage" -swift-version "$vers" -o /dev/null ; then
     echo "  Success"
   else
     exit $?

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,20 @@ jobs:
     - name: Validate SPI Manifest
       run: swift package plugin validate-spi-manifest
   compile-snapshots:
-    name: Compile Snapshots
+    name: Compile Snapshots (Swift ${{ matrix.swift-version }})
     runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        swift-version: ["5", "6"]
+        include:
+        - swift-version: "5"
+          xcode: "15.4"
+        - swift-version: "6"
+          xcode: "16.0"
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+      SWIFT_VERSION: ${{ matrix.swift-version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableStructSnippet.swift
+++ b/Sources/StringGenerator/Snippets/LocalizedStringResource/StringsTable/LocalizedStringResourceStringsTableStructSnippet.swift
@@ -10,7 +10,8 @@ extension LocalizedStringResourceStringsTableStructSnippet: Snippet {
         StructDeclSyntax(
             leadingTrivia: leadingTrivia,
             modifiers: modifiers,
-            name: stringsTable.type
+            name: stringsTable.type,
+            inheritanceClause: inheritanceClause
         ) {
             for (position, accessor) in stringsTable.accessors.withPosition {
                 MemberBlockItemListSyntax {
@@ -27,6 +28,10 @@ extension LocalizedStringResourceStringsTableStructSnippet: Snippet {
 
     var leadingTrivia: Trivia? {
         Trivia(docComment: stringsTable.headerDocumentation)
+    }
+
+    var inheritanceClause: InheritanceClauseSyntax? {
+        InheritanceClauseSyntax(.Sendable)
     }
 
     @DeclModifierListBuilder

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -407,7 +407,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.FormatSpecifiers`` requires iOS 16/macOS 13 or later. See ``String.FormatSpecifiers`` for a backwards compatible API.
-    internal struct FormatSpecifiers {
+    internal struct FormatSpecifiers: Sendable {
         /// %@ should convert to a String argument
         ///
         /// ### Source Localization

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -260,7 +260,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for a backwards compatible API.
-    internal struct Localizable {
+    internal struct Localizable: Sendable {
         /// A key that conflicts with a keyword in swift that isn't suitable for a variable/method and should be backticked.
         ///
         /// ### Source Localization

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -202,7 +202,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Multiline`` requires iOS 16/macOS 13 or later. See ``String.Multiline`` for a backwards compatible API.
-    internal struct Multiline {
+    internal struct Multiline: Sendable {
         /// This example tests the following:
         /// 1. That line breaks in the defaultValue are supported
         /// 2. That line breaks in the comment are supported

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -236,7 +236,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Positional`` requires iOS 16/macOS 13 or later. See ``String.Positional`` for a backwards compatible API.
-    internal struct Positional {
+    internal struct Positional: Sendable {
         /// A string where the second argument is at the front of the string and the first argument is at the end
         ///
         /// ### Source Localization

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -197,7 +197,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Simple`` requires iOS 16/macOS 13 or later. See ``String.Simple`` for a backwards compatible API.
-    internal struct Simple {
+    internal struct Simple: Sendable {
         /// This is a simple key and value
         ///
         /// ### Source Localization

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -201,7 +201,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Substitution`` requires iOS 16/macOS 13 or later. See ``String.Substitution`` for a backwards compatible API.
-    internal struct Substitution {
+    internal struct Substitution: Sendable {
         /// A string that uses substitutions as well as arguments
         ///
         /// ### Source Localization

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -213,7 +213,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Variations`` requires iOS 16/macOS 13 or later. See ``String.Variations`` for a backwards compatible API.
-    internal struct Variations {
+    internal struct Variations: Sendable {
         /// A string that should have a macOS variation to replace 'Tap' with 'Click'
         ///
         /// ### Source Localization

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
@@ -278,7 +278,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Legacy`` requires iOS 16/macOS 13 or later. See ``String.Legacy`` for a backwards compatible API.
-    internal struct Legacy {
+    internal struct Legacy: Sendable {
         /// ### Source Localization
         ///
         /// ```

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
@@ -261,7 +261,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Legacy`` requires iOS 16/macOS 13 or later. See ``String.Legacy`` for a backwards compatible API.
-    internal struct Legacy {
+    internal struct Legacy: Sendable {
         /// ### Source Localization
         ///
         /// ```

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
@@ -198,7 +198,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Legacy`` requires iOS 16/macOS 13 or later. See ``String.Legacy`` for a backwards compatible API.
-    internal struct Legacy {
+    internal struct Legacy: Sendable {
         /// ### Source Localization
         ///
         /// ```

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -260,7 +260,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for a backwards compatible API.
-    package struct Localizable {
+    package struct Localizable: Sendable {
         /// A key that conflicts with a keyword in swift that isn't suitable for a variable/method and should be backticked.
         ///
         /// ### Source Localization

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -260,7 +260,7 @@ extension LocalizedStringResource {
     /// ```
     ///
     /// - Note: Using ``LocalizedStringResource.Localizable`` requires iOS 16/macOS 13 or later. See ``String.Localizable`` for a backwards compatible API.
-    public struct Localizable {
+    public struct Localizable: Sendable {
         /// A key that conflicts with a keyword in swift that isn't suitable for a variable/method and should be backticked.
         ///
         /// ### Source Localization


### PR DESCRIPTION
While testing in preparation for 0.5.1, I realised that I am missing tests to ensure that the generated source actually compiles in Swift 6 language mode.

When adding them, I found that `LocalizableStringResource.Localizable` fails to compile when `public` because it's not annotated as `Sendable`. Therefore I also added this annotation. 