### PR TITLE
Pin dependencies to swiftlang GitHub organisation (was apple) and remove .git suffix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,14 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+    - name: Downgrade swift-snapshot-testing
+      if: matrix.xcode == '16.0'
+      run: |
+        # Use 1.17.0 until macOS-14 runner is updated to Xcode 16 Beta 3
+        # https://github.com/pointfreeco/swift-snapshot-testing/pull/869
+        if xcodebuild -version | grep 16A5171r; then
+          jq '(.pins[] | select(.identity == "swift-snapshot-testing") | .state.revision) = "f6c51fa7609b1057ca5420127440413c54971ff6" | (.pins[] | select(.identity == "swift-snapshot-testing") | .state.version) = "1.17.0"' Package.resolved | sed 's/": /" : /g' > Package.resolved.tmp && mv Package.resolved.tmp Package.resolved
+        fi
     - name: Run Tests
       run: xcodebuild clean test -scheme XCStringsTool-Package -destination platform=macOS
   unit-test-swift-syntax:

--- a/Package.resolved
+++ b/Package.resolved
@@ -12,7 +12,7 @@
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
         "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
         "version" : "1.3.0"
@@ -30,16 +30,16 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "8ddd519780452729c6634ad6bd0d2595938e9ea3",
-        "version" : "1.16.1"
+        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
+        "version" : "1.17.2"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"

--- a/Package.swift
+++ b/Package.swift
@@ -16,10 +16,10 @@ let package = Package(
         .library(name: "StringCatalog", targets: ["StringCatalog"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
-        .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0" ..< "601.0.0"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.13.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0" ..< "601.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.13.0"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -174,8 +174,8 @@ if ProcessInfo.processInfo.environment.keys.contains("BENCHMARK_PACKAGE") {
 // Support testing different versions of Swift Syntax
 if let revision = ProcessInfo.processInfo.environment["SWIFT_SYNTAX_REVISION"] {
     // TODO: The `kind` symbol isn't available in Xcode 15.2? Check newer versions.
-    package.dependencies.removeAll(where: { $0.url == "https://github.com/apple/swift-syntax.git" })
+    package.dependencies.removeAll(where: { $0.url == "https://github.com/swiftlang/swift-syntax" })
     package.dependencies.append(
-        .package(url: "https://github.com/apple/swift-syntax.git", revision: revision)
+        .package(url: "https://github.com/swiftlang/swift-syntax", revision: revision)
     )
 }


### PR DESCRIPTION
- https://www.swift.org/blog/swiftlang-github/

swift-syntax and swift-docc-plugin have moved to the swiftlang org on GitHub, while the existing links work, it can start to cause warnings to popup when mixing and matching urls. 

This change updates our dependency definitions to use the new org which is what will happen with all packages eventually.

I also drop the .git suffix from the urls since it is redundant. 

As part of this change, the pinned version of swift-snapshot-testing has been updated from 1.16.1 to 1.17.2.