### PR TITLE
Fix "'retroactive' attribute does not apply here" error when using Xcode 16 RC 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
         - "509.0.2"
         - "509.1.1"
         - "510.0.2"
-        - "600.0.0-prerelease-2024-06-12"
+        - "600.0.0"
         include:
         - swift-syntax: "509.0.2"
           revision: 6ad4ea24b01559dde0773e3d091f1b9e36175036
@@ -90,8 +90,8 @@ jobs:
           revision: 64889f0c732f210a935a0ad7cda38f77f876262d
         - swift-syntax: "510.0.2"
           revision: 303e5c5c36d6a558407d364878df131c3546fad8
-        - swift-syntax: "600.0.0-prerelease-2024-06-12"
-          revision: 4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c
+        - swift-syntax: "600.0.0"
+          revision: cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25
     runs-on: macOS-14
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
-        "version" : "1.17.2"
+        "revision" : "7b0bbbae90c41f848f90ac7b4df6c4f50068256d",
+        "version" : "1.17.5"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
-        "version" : "600.0.0-prerelease-2024-06-12"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     }
   ],

--- a/Sources/xcstrings-tool/Utilities/AccessLevel+Resolution.swift
+++ b/Sources/xcstrings-tool/Utilities/AccessLevel+Resolution.swift
@@ -32,7 +32,7 @@ extension AccessLevel {
 }
 
 #if compiler(>=6.0)
-extension AccessLevel: @retroactive ExpressibleByArgument {}
+extension AccessLevel: @retroactive ArgumentParser.ExpressibleByArgument {}
 #else
 extension AccessLevel: ExpressibleByArgument {}
 #endif


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a6042cc2-0caf-4069-916b-51cac3e35bfd)
