### PR TITLE
Fix variable name from string catalog with an acronym in the name

### DIFF
--- a/Sources/SwiftIdentifier/SwiftIdentifier+Extra.swift
+++ b/Sources/SwiftIdentifier/SwiftIdentifier+Extra.swift
@@ -1,14 +1,28 @@
 import Foundation
 
 private extension String {
-    var lowercaseFirst: String {
-        guard let first = unicodeScalars.first else { return self }
-        return String(first).lowercased() + String(unicodeScalars.dropFirst())
+    func lowercaseFirst(_ n: Int) -> String {
+        guard unicodeScalars.count >= n else { return self }
+        return String(unicodeScalars.prefix(n)).lowercased() + String(unicodeScalars.dropFirst(n))
     }
 }
 
 extension SwiftIdentifier {
     public static func variableIdentifier(for string: String) -> String {
-        identifier(from: string).lowercaseFirst
+        let identifier = identifier(from: string)
+        let uppercasedPrefix = identifier.prefix(while: \.isUppercase)
+
+        if uppercasedPrefix.isEmpty {
+            return identifier
+        } else if uppercasedPrefix.unicodeScalars.count == 1 {
+            // i.e "Localizable" >> "localizable" or "MyStrings" >> "myStrings"
+            return identifier.lowercaseFirst(1)
+        } else if uppercasedPrefix.count == identifier.count {
+            // i.e "LOCALIZABLE" >> "localizable"
+            return identifier.lowercased()
+        } else {
+            // i.e "URLStrings" >> "urlStrings" or "URLStringCollection" >> "urlStringCollection"
+            return identifier.lowercaseFirst(uppercasedPrefix.unicodeScalars.count - 1)
+        }
     }
 }

--- a/Tests/XCStringsToolTests/SwiftIdentifierTests.swift
+++ b/Tests/XCStringsToolTests/SwiftIdentifierTests.swift
@@ -1,0 +1,41 @@
+import SwiftIdentifier
+import XCTest
+
+final class SwiftIdentifierTests: XCTestCase {
+    func testSwiftIdentifier() {
+        assert(value: "Localizable", escapesTo: "Localizable", "localizable")
+        assert(value: "localizable", escapesTo: "Localizable", "localizable")
+        assert(value: "LOCALIZABLE", escapesTo: "LOCALIZABLE", "localizable")
+
+        assert(value: "URL Strings", escapesTo: "URLStrings", "urlStrings")
+        assert(value: "URLStrings", escapesTo: "URLStrings", "urlStrings")
+
+        assert(value: "FeatureFoo", escapesTo: "FeatureFoo", "featureFoo")
+        assert(value: "Feature Foo", escapesTo: "FeatureFoo", "featureFoo")
+        assert(value: "Feature URL", escapesTo: "FeatureURL", "featureURL")
+    }
+
+    private func assert(
+        value: String,
+        escapesTo expectedIdentifier: String,
+        _ expectedVariableIdentifier: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            SwiftIdentifier.identifier(from: value),
+            expectedIdentifier,
+            "identifier",
+            file: file,
+            line: line
+        )
+
+        XCTAssertEqual(
+            SwiftIdentifier.variableIdentifier(for: value),
+            expectedVariableIdentifier,
+            "variableIdentifier",
+            file: file,
+            line: line
+        )
+    }
+}


### PR DESCRIPTION
If a Strings Catalog contained an uppercase acronym at the start, the variable  name generated would incorrectly only lowercase the first character.

For example:

URLStrings.xcstrings would generate a struct called `URLStrings` as expected, but the variable/label would be `uRLStrings` which is not expected.

In this PR, I update the logic so that we lowercase the n-1 initial characters if more than 1 character is uppercased at the start of the string.

This means that the example above will generate a variable named `urlStrings`