### PR TITLE
Enhance the documentation quality

### DIFF
--- a/Sources/Documentation/XCStringsToolPlugin.docc/Integrating XCStrings Tool into a Swift Package Target.md
+++ b/Sources/Documentation/XCStringsToolPlugin.docc/Integrating XCStrings Tool into a Swift Package Target.md
@@ -80,7 +80,7 @@ If you wish, you can open the file printed in the log output to review the gener
 
 This code is compiled as part of your target, so is accessible just like code you would write yourself:
 
-![A screenshot of the new constants being used in some Foundation-baed model code](SPM-Usage)
+![A screenshot of the new constants being used in some Foundation-based model code](SPM-Usage)
 
 ## See Also
 

--- a/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
+++ b/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
@@ -32,7 +32,7 @@ extension SourceFile.StringExtension {
             BundleDescriptionEnum(stringsTable: self)
         }
 
-        // MARK: Properites
+        // MARK: Properties
 
         var storedProperties: [Property] {
             [keyProperty, argumentsProperty, tableProperty]

--- a/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
+++ b/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
@@ -85,7 +85,7 @@ extension SourceFile.StringExtension {
 
         In Foundation, you can resolve the localized string using the system language
         with the `String`.``Swift/String/init(\(sourceFile.tableVariableIdentifier):locale:)``
-        intializer:
+        initializer:
 
         ```swift
         // Accessing the localized value directly

--- a/Sources/xcstrings-tool/Utilities/InputParser.swift
+++ b/Sources/xcstrings-tool/Utilities/InputParser.swift
@@ -54,7 +54,7 @@ struct InputParser {
                 throw Error.notALocalizedResource(fileURL)
             }
 
-            // Include the file if the language matches the developmentLaguage
+            // Include the file if the language matches the developmentLanguage
             let language = lprojDir.replacingOccurrences(of: ".lproj", with: "", options: .caseInsensitive)
             return language.localizedCaseInsensitiveCompare(developmentLanguage) == .orderedSame
         }

--- a/Tests/PluginTests/Resources/fr.lproj/Legacy.strings
+++ b/Tests/PluginTests/Resources/fr.lproj/Legacy.strings
@@ -1,1 +1,1 @@
-"Ignored" = "This file should be ignored becuase it is not the development language";
+"Ignored" = "This file should be ignored because it is not the development language";

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(formatSpecifiers:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(localizable:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(multiline:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(positional:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(simple:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(substitution:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(variations:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(legacy:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(legacy:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(legacy:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(localizable:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -13,7 +13,7 @@ extension String {
     ///
     /// In Foundation, you can resolve the localized string using the system language
     /// with the `String`.``Swift/String/init(localizable:locale:)``
-    /// intializer:
+    /// initializer:
     ///
     /// ```swift
     /// // Accessing the localized value directly


### PR DESCRIPTION
Fixed a bunch of typos, keeping the British-English as the source of truth (based on the presence of the word `customise`)