### PR TITLE
Enhance the code quality

### DIFF
--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableDefaultValueComputedPropertySnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableDefaultValueComputedPropertySnippet.swift
@@ -61,7 +61,7 @@ struct StringStringsTableDefaultValueComputedPropertySnippet: Snippet {
             )
 
             // let makeDefaultValue = String.LocalizationValue.init(stringInterpolation:)
-            ExpressibleByStringInterplationInitializerClosureSnippet(
+            ExpressibleByStringInterpolationInitializerClosureSnippet(
                 variableName: "makeDefaultValue",
                 type: MemberAccessExprSyntax(
                     .type(.String), .type(.LocalizationValue)

--- a/Sources/StringGenerator/Snippets/StringInterpolation/ExpressibleByStringInterpolationInitializerClosureSnippet.swift
+++ b/Sources/StringGenerator/Snippets/StringInterpolation/ExpressibleByStringInterpolationInitializerClosureSnippet.swift
@@ -1,12 +1,12 @@
 import SwiftSyntax
 
-struct ExpressibleByStringInterplationInitializerClosureSnippet<T: ExprSyntaxProtocol> {
+struct ExpressibleByStringInterpolationInitializerClosureSnippet<T: ExprSyntaxProtocol> {
     var bindingSpecifier: Keyword = .let
     let variableName: TokenSyntax
     let type: T
 }
 
-extension ExpressibleByStringInterplationInitializerClosureSnippet: Snippet {
+extension ExpressibleByStringInterpolationInitializerClosureSnippet: Snippet {
     var syntax: some DeclSyntaxProtocol {
         // let {variableName} = {type}.init(stringInterpolation:)
         VariableDeclSyntax(bindingSpecifier: .keyword(bindingSpecifier)) {

--- a/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyInitializerSnippet.swift
@@ -76,7 +76,7 @@ extension LocalizedStringKeyInitializerSnippet: Snippet {
 
             // let makeKey = LocalizedStringKey.init(stringInterpolation:)
             // self = makeKey(stringInterpolation)
-            ExpressibleByStringInterplationInitializerClosureSnippet(
+            ExpressibleByStringInterpolationInitializerClosureSnippet(
                 variableName: "makeKey",
                 type: DeclReferenceExprSyntax(baseName: .type(.LocalizedStringKey))
             )

--- a/Sources/StringGenerator/Snippets/SwiftUI/TextInitializerSnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/TextInitializerSnippet.swift
@@ -63,7 +63,7 @@ extension TextInitializerSnippet: Snippet {
                 variableName: "stringInterpolation"
             )
 
-            ExpressibleByStringInterplationInitializerClosureSnippet(
+            ExpressibleByStringInterpolationInitializerClosureSnippet(
                 variableName: "makeKey",
                 type: DeclReferenceExprSyntax(baseName: .type(.LocalizedStringKey))
             )


### PR DESCRIPTION
Fix a typo in the word `Interpolation` in the `file name`, `function name` and wherever it used