### PR TITLE
Update CI workflows to check Xcode 16.1 and macOS 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   build-artifactbundle:
     name: Build Executable
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   validate-spi-manifest:
     name: Validate SPI Manifest
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
       VALIDATE_SPI_MANIFEST: YES
     steps:
     - name: Checkout Repo
@@ -22,18 +22,13 @@ jobs:
       run: swift package plugin validate-spi-manifest
   compile-snapshots:
     name: Compile Snapshots (Swift ${{ matrix.swift-version }})
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
         swift-version: ["5", "6"]
-        include:
-        - swift-version: "5"
-          xcode: "15.4"
-        - swift-version: "6"
-          xcode: "16.0"
     env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
       SWIFT_VERSION: ${{ matrix.swift-version }}
     steps:
     - name: Checkout Repo
@@ -45,7 +40,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["15.0", "15.2", "15.3", "15.4"]
         include:
         - xcode: "15.0"
           macos: macOS-13
@@ -56,21 +50,15 @@ jobs:
         - xcode: "15.4"
           macos: macOS-14
         - xcode: "16.0"
-          macos: macOS-14
+          macos: macOS-15
+        - xcode: "16.1"
+          macos: macOS-15
     runs-on: ${{ matrix.macos }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Downgrade swift-snapshot-testing
-      if: matrix.xcode == '16.0'
-      run: |
-        # Use 1.17.0 until macOS-14 runner is updated to Xcode 16 Beta 3
-        # https://github.com/pointfreeco/swift-snapshot-testing/pull/869
-        if xcodebuild -version | grep 16A5171r; then
-          jq '(.pins[] | select(.identity == "swift-snapshot-testing") | .state.revision) = "f6c51fa7609b1057ca5420127440413c54971ff6" | (.pins[] | select(.identity == "swift-snapshot-testing") | .state.version) = "1.17.0"' Package.resolved | sed 's/": /" : /g' > Package.resolved.tmp && mv Package.resolved.tmp Package.resolved
-        fi
     - name: Run Tests
       run: xcodebuild clean test -scheme XCStringsTool-Package -destination platform=macOS
   unit-test-swift-syntax:
@@ -82,7 +70,7 @@ jobs:
         - "509.0.2"
         - "509.1.1"
         - "510.0.2"
-        - "600.0.0"
+        - "600.0.1"
         include:
         - swift-syntax: "509.0.2"
           revision: 6ad4ea24b01559dde0773e3d091f1b9e36175036
@@ -90,11 +78,11 @@ jobs:
           revision: 64889f0c732f210a935a0ad7cda38f77f876262d
         - swift-syntax: "510.0.2"
           revision: 303e5c5c36d6a558407d364878df131c3546fad8
-        - swift-syntax: "600.0.0"
-          revision: cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25
-    runs-on: macOS-14
+        - swift-syntax: "600.0.1"
+          revision: 0687f71944021d616d34d922343dcef086855920
+    runs-on: macOS-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4


### PR DESCRIPTION
- https://github.com/actions/runner-images/issues/10703

This Pull Request updates the workflow configurations to use macOS 15 and Xcode 16.1 as the primary OS for checks.

In addition, some minor adjustments are made reflect changes in runner images as referenced in the ticket linked above.