### PR TITLE
Allows to override the Bundle.module

### DIFF
--- a/Sources/StringGenerator/Models/SourceFile.swift
+++ b/Sources/StringGenerator/Models/SourceFile.swift
@@ -11,6 +11,9 @@ struct SourceFile {
     /// The access level to be used when generating non-private interfaces
     let accessLevel: AccessLevel
 
+    /// An optional bundle identifier that overrides the default bundle for resource lookup.
+    let bundleOverride: String?
+
     /// The string resources that make up the strings table
     let resources: [Resource]
 }

--- a/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
+++ b/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
@@ -24,6 +24,10 @@ extension SourceFile.StringExtension {
             sourceFile.accessLevel
         }
 
+        var bundleOverride: String? {
+            sourceFile.bundleOverride
+        }
+
         var argumentEnum: ArgumentEnum {
             ArgumentEnum(stringsTable: self)
         }

--- a/Sources/StringGenerator/Snippets/String/StringsTable/Bundle/StringStringsTableBundleComputedPropertySnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/Bundle/StringStringsTableBundleComputedPropertySnippet.swift
@@ -33,7 +33,7 @@ struct StringStringsTableBundleComputedPropertySnippet: Snippet {
         IfConfigDeclSyntax(
             reference: "SWIFT_PACKAGE",
             elements: .statements([
-                CodeBlockItemSyntax(item: .expr(ExprSyntax(".module")))
+                CodeBlockItemSyntax(item: .expr(ExprSyntax(stringLiteral: stringsTable.bundleOverride ?? ".module")))
             ]),
             else: .statements([
                 CodeBlockItemSyntax(item: .expr(ExprSyntax("Bundle(for: BundleLocator.self)")))

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -10,10 +10,16 @@ public struct StringGenerator {
     public static func generateSource(
         for resources: [Resource],
         tableName: String,
-        accessLevel: AccessLevel
+        accessLevel: AccessLevel,
+        bundleOverride: String?
     ) -> String {
         generateSource(
-            for: SourceFile(tableName: tableName, accessLevel: accessLevel, resources: resources)
+            for: SourceFile(
+                tableName: tableName,
+                accessLevel: accessLevel,
+                bundleOverride: bundleOverride,
+                resources: resources
+            )
         )
     }
 

--- a/Sources/xcstrings-tool/Generate.swift
+++ b/Sources/xcstrings-tool/Generate.swift
@@ -50,6 +50,12 @@ struct Generate: ParsableCommand {
     )
     var developmentLanguage: String?
 
+    @Option(
+        name: .shortAndLong,
+        help: "The bundle override. Used to override the default bundle (Bundle.module) for resource lookup."
+    )
+    var bundleOverride: String?
+
     @Flag(name: .shortAndLong)
     var verbose: Bool = false
 
@@ -97,7 +103,8 @@ struct Generate: ParsableCommand {
         let source = StringGenerator.generateSource(
             for: resources,
             tableName: input.tableName,
-            accessLevel: configuration.accessLevel
+            accessLevel: configuration.accessLevel,
+            bundleOverride: configuration.bundleOverride
         )
 
         // Write the output and catch errors in a diagnostic format

--- a/Sources/xcstrings-tool/Utilities/Configuration.swift
+++ b/Sources/xcstrings-tool/Utilities/Configuration.swift
@@ -7,14 +7,17 @@ struct Configuration {
         enum CodingKeys: String, CodingKey {
             case accessLevel = "access_level"
             case developmentLanguage = "development_language"
+            case bundleOverride = "bundle_override"
         }
 
         var accessLevel: AccessLevel?
         var developmentLanguage: String?
+        var bundleOverride: String?
     }
 
     var accessLevel: AccessLevel
     var developmentLanguage: String?
+    var bundleOverride: String?
 }
 
 extension Configuration {
@@ -32,10 +35,11 @@ extension Configuration {
         // Resolve values from either the config file, environment, or arguments
         let accessLevel = file?.accessLevel ?? .resolveFromEnvironment(environment, or: command.accessLevel) ?? .internal
         let developmentLanguage = file?.developmentLanguage ?? command.developmentLanguage ?? environment["DEVELOPMENT_LANGUAGE"]
-
+        let bundleOverride = file?.bundleOverride ?? command.bundleOverride
         self.init(
             accessLevel: accessLevel,
-            developmentLanguage: developmentLanguage
+            developmentLanguage: developmentLanguage,
+            bundleOverride: bundleOverride
         )
     }
 }

--- a/Tests/PluginTests/Bundle.swift
+++ b/Tests/PluginTests/Bundle.swift
@@ -1,0 +1,46 @@
+//
+//  Bundle.swift
+//  XCStringsTool
+//
+//  Created by Roberto Casula on 02/03/25.
+//
+
+import Foundation
+
+#if DEBUG
+    private class BundleFinder {}
+#endif
+
+extension Foundation.Bundle {
+    static let current: Bundle = {
+        #if DEBUG
+        let bundleName = "XCStringsTool_PluginTests"
+
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: BundleFinder.self).resourceURL,
+
+            // For command-line tools.
+            Bundle.main.bundleURL,
+
+            // Bundle should be present here when running previews
+            // from a different package (this is the path to "…/Debug-iphonesimulator/").
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent()
+                .deletingLastPathComponent(),
+        ]
+
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+        fatalError("unable to find bundle named \(bundleName)")
+        #else
+        .module
+        #endif
+    }()
+}

--- a/Tests/PluginTests/xcstrings-tool.yml
+++ b/Tests/PluginTests/xcstrings-tool.yml
@@ -1,2 +1,3 @@
 access_level: public
 development_language: en
+bundle_override: Bundle.current


### PR DESCRIPTION
This MR will allow us to override the default Bundle when generating resources strings.
Fixes https://github.com/liamnichols/xcstrings-tool/issues/111 and https://github.com/liamnichols/xcstrings-tool/pull/121