### PR TITLE
Update SwiftSyntax 6.2 tests to use 602.0.0-prerelease-2025-05-29

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,8 +81,8 @@ jobs:
           revision: 0687f71944021d616d34d922343dcef086855920
         - swift-syntax: "601.0.1"
           revision: f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2
-        - swift-syntax: "602.0.0-prerelease-2025-04-16"
-          revision: 340f8400262d494c7c659cd838223990195d7fed
+        - swift-syntax: "602.0.0-prerelease-2025-05-29"
+          revision: 0dff260d3d1bb99c382d8dfcd6bb093e5e9cbd36
     runs-on: macOS-15
     env:
       DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer


### PR DESCRIPTION
There is a new prerelease out so we should be running tests against that instead. 