### PR TITLE
Fix issue where overrideKeyForLookup will crash in release builds

### DIFF
--- a/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyOverrideKeySnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyOverrideKeySnippet.swift
@@ -15,8 +15,9 @@ struct LocalizedStringKeyOverrideKeySnippet: Snippet {
         fileprivate mutating func overrideKeyForLookup(using key: String) {
             withUnsafeMutablePointer(to: &self) { pointer in
                 let raw = UnsafeMutableRawPointer(pointer)
-                let bound = raw.assumingMemoryBound(to: String.self)
-                bound.pointee = key
+                raw.withMemoryRebound(to: String.self, capacity: 1) { rebound in
+                  rebound.pointee = key
+                }
             }
         }
         """)

--- a/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyOverrideKeySnippet.swift
+++ b/Sources/StringGenerator/Snippets/SwiftUI/LocalizedStringKeyOverrideKeySnippet.swift
@@ -15,8 +15,8 @@ struct LocalizedStringKeyOverrideKeySnippet: Snippet {
         fileprivate mutating func overrideKeyForLookup(using key: String) {
             withUnsafeMutablePointer(to: &self) { pointer in
                 let raw = UnsafeMutableRawPointer(pointer)
-                raw.withMemoryRebound(to: String.self, capacity: 1) { rebound in
-                  rebound.pointee = key
+                raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+                  bound.pointee = key
                 }
             }
         }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.FormatSpecifiers.swift
@@ -449,8 +449,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Localizable.swift
@@ -336,8 +336,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Multiline.swift
@@ -256,8 +256,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Positional.swift
@@ -288,8 +288,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Simple.swift
@@ -251,8 +251,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Substitution.swift
@@ -255,8 +255,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerate.Variations.swift
@@ -266,8 +266,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithConvertFromSnakeCase.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithConvertFromSnakeCase.Localizable.swift
@@ -336,8 +336,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithImportsUseExplicitAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithImportsUseExplicitAccessLevel.Localizable.swift
@@ -344,8 +344,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyFilesCombined.Legacy.swift
@@ -327,8 +327,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStrings.Legacy.swift
@@ -311,8 +311,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithLegacyStringsdict.Legacy.swift
@@ -252,8 +252,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPackageAccessLevel.Localizable.swift
@@ -336,8 +336,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }

--- a/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
+++ b/Tests/XCStringsToolTests/__Snapshots__/GenerateTests/testGenerateWithPublicAccessLevel.Localizable.swift
@@ -336,8 +336,9 @@ extension LocalizedStringKey {
     fileprivate mutating func overrideKeyForLookup(using key: String) {
         withUnsafeMutablePointer(to: &self) { pointer in
             let raw = UnsafeMutableRawPointer(pointer)
-            let bound = raw.assumingMemoryBound(to: String.self)
-            bound.pointee = key
+            raw.withMemoryRebound(to: String.self, capacity: 1) { bound in
+              bound.pointee = key
+            }
         }
     }
 }


### PR DESCRIPTION
On Xcode 26 we found that iOS 15 release builds started crashing when resolving interpolated localised strings. This turned out to be related to the generated `overrideKeyForLookup`. Changing from `assumingMemoryRebound` to `withMemoryRebound` fixes the crash and doesn't seem to have any unexpected side effects. The strings still resolve to the expected values.

This PR implements that fix.

However we also wondered if there is an alternative, for example while the generated `LocalizedStringKey.localizable` path ends up in the `overrideKeyForLookup` method on iOS 15, the `String.localizable` path does not. Is there a way to use the more direct and safer path from `String.localizable`?

In any event this PR should fix the issue we were experiencing.

Please let me know if you need anything from us. We do have a tiny example project illustrating the issue if you'd like to see it.