### PR TITLE
Remove incorrect @retroactive from AccessLevel conformance

### DIFF
--- a/Sources/xcstrings-tool/Utilities/AccessLevel+Resolution.swift
+++ b/Sources/xcstrings-tool/Utilities/AccessLevel+Resolution.swift
@@ -32,7 +32,7 @@ extension AccessLevel {
 }
 
 #if compiler(>=6.0)
-extension AccessLevel: @retroactive ArgumentParser.ExpressibleByArgument {}
+extension AccessLevel: ArgumentParser.ExpressibleByArgument {}
 #else
 extension AccessLevel: ExpressibleByArgument {}
 #endif


### PR DESCRIPTION
The @retroactive attribute is intended for types defined in external modules. `AccessLevel` is defined within this package, so the attribute should not be used.

In line with https://github.com/liamnichols/xcstrings-tool/pull/148 and https://github.com/liamnichols/xcstrings-tool/pull/145 where the authors closed the PR.

Closes #147 and #146.