### PR TITLE
feat(generator): add --namespace-grouping option

### DIFF
--- a/Sources/StringGenerator/Models/SourceFile.swift
+++ b/Sources/StringGenerator/Models/SourceFile.swift
@@ -17,6 +17,9 @@ struct SourceFile {
     /// Supporting SE0409
     let importsUseExplicitAccessLevel: Bool
 
+    /// Group accessors into nested enums by the first dot-component of each key
+    let namespaceGrouping: Bool
+
     /// The string resources that make up the strings table
     let resources: [Resource]
 }

--- a/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
+++ b/Sources/StringGenerator/Models/SourceFile_StringExtension_StringsTableStruct.swift
@@ -1,4 +1,5 @@
 import StringResource
+import SwiftIdentifier
 import SwiftSyntax
 import XCStringsToolConstants
 
@@ -18,6 +19,51 @@ extension SourceFile.StringExtension {
             sourceFile.resources.map { resource in
                 ResourceAccessor(sourceFile: sourceFile, resource: resource)
             }
+        }
+
+        struct NamespaceGroup {
+            let enumName: TokenSyntax
+            let members: [(accessor: ResourceAccessor, memberName: TokenSyntax)]
+        }
+
+        var namespaceGroups: [NamespaceGroup]? {
+            guard sourceFile.namespaceGrouping else { return nil }
+
+            var groupOrder: [String] = []
+            var groupedMembers: [String: [(ResourceAccessor, TokenSyntax)]] = [:]
+
+            for accessor in accessors {
+                let key = accessor.resource.key
+                guard let dotIndex = key.firstIndex(of: ".") else { continue }
+
+                let namespace = String(key[key.startIndex..<dotIndex])
+                let memberKey = String(key[key.index(after: dotIndex)...])
+                let memberName = TokenSyntax.identifier(
+                    SwiftIdentifier.variableIdentifier(for: memberKey)
+                        .snakeCaseConverted(sourceFile.convertFromSnakeCase)
+                        .backtickedVariableNameIfNeeded
+                )
+
+                if groupedMembers[namespace] == nil {
+                    groupOrder.append(namespace)
+                    groupedMembers[namespace] = []
+                }
+                groupedMembers[namespace]!.append((accessor, memberName))
+            }
+
+            guard !groupOrder.isEmpty else { return nil }
+
+            return groupOrder.map { namespace in
+                NamespaceGroup(
+                    enumName: .identifier(SwiftIdentifier.identifier(from: namespace)),
+                    members: groupedMembers[namespace]!
+                )
+            }
+        }
+
+        var ungroupedAccessors: [ResourceAccessor] {
+            guard sourceFile.namespaceGrouping else { return accessors }
+            return accessors.filter { !$0.resource.key.contains(".") }
         }
 
         var accessLevel: AccessLevel {

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableNamespaceEnumSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableNamespaceEnumSnippet.swift
@@ -1,0 +1,41 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+struct StringStringsTableNamespaceEnumSnippet: Snippet {
+    let group: SourceFile.StringExtension.StringsTableStruct.NamespaceGroup
+    let stringsTable: SourceFile.StringExtension.StringsTableStruct
+
+    var syntax: some DeclSyntaxProtocol {
+        EnumDeclSyntax(
+            modifiers: modifiers,
+            name: group.enumName,
+            memberBlock: memberBlock
+        )
+    }
+
+    @DeclModifierListBuilder
+    var modifiers: DeclModifierListSyntax {
+        DeclModifierSyntax(name: stringsTable.accessLevel.token)
+    }
+
+    var memberBlock: MemberBlockSyntax {
+        MemberBlockSyntax {
+            for (accessor, memberName) in group.members {
+                MemberBlockItemListSyntax {
+                    if accessor.hasArguments {
+                        StringStringsTableResourceFunctionSnippet(
+                            accessor: accessor,
+                            nameOverride: memberName
+                        )
+                    } else {
+                        StringStringsTableResourceVariableSnippet(
+                            accessor: accessor,
+                            nameOverride: memberName
+                        )
+                    }
+                }
+                .with(\.trailingTrivia, .newlines(2))
+            }
+        }
+    }
+}

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableResourceFunctionSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableResourceFunctionSnippet.swift
@@ -3,12 +3,15 @@ import SwiftSyntaxBuilder
 
 struct StringStringsTableResourceFunctionSnippet: Snippet {
     let accessor: SourceFile.StringExtension.StringsTableStruct.ResourceAccessor
+    var nameOverride: TokenSyntax? = nil
+
+    var effectiveName: TokenSyntax { nameOverride ?? accessor.variableName }
 
     var syntax: some DeclSyntaxProtocol {
         FunctionDeclSyntax(
             leadingTrivia: leadingTrivia,
             modifiers: modifiers,
-            name: accessor.variableName,
+            name: effectiveName,
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax {
                     for argument in accessor.resource.arguments {

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableResourceVariableSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableResourceVariableSnippet.swift
@@ -3,6 +3,9 @@ import SwiftSyntaxBuilder
 
 struct StringStringsTableResourceVariableSnippet: Snippet {
     let accessor: SourceFile.StringExtension.StringsTableStruct.ResourceAccessor
+    var nameOverride: TokenSyntax? = nil
+
+    var effectiveName: TokenSyntax { nameOverride ?? accessor.variableName }
 
     var syntax: some DeclSyntaxProtocol {
         VariableDeclSyntax(
@@ -11,7 +14,7 @@ struct StringStringsTableResourceVariableSnippet: Snippet {
             bindingSpecifier: .keyword(.var),
             bindings: [
                 PatternBindingSyntax(
-                    pattern: IdentifierPatternSyntax(identifier: accessor.variableName),
+                    pattern: IdentifierPatternSyntax(identifier: effectiveName),
                     typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: accessor.type)),
                     accessorBlock: AccessorBlockSyntax(
                         accessors: .getter(getter)

--- a/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
+++ b/Sources/StringGenerator/Snippets/String/StringsTable/StringStringsTableStructSnippet.swift
@@ -82,15 +82,33 @@ struct StringStringsTableStructSnippet: Snippet {
             }
             .with(\.trailingTrivia, .newlines(2))
 
-            for accessor in stringsTable.accessors {
-                MemberBlockItemListSyntax {
-                    if accessor.hasArguments {
-                        StringStringsTableResourceFunctionSnippet(accessor: accessor)
-                    } else {
-                        StringStringsTableResourceVariableSnippet(accessor: accessor)
-                    }
+            if let groups = stringsTable.namespaceGroups {
+                for group in groups {
+                    StringStringsTableNamespaceEnumSnippet(group: group, stringsTable: stringsTable)
+                        .syntax
+                        .with(\.trailingTrivia, .newlines(2))
                 }
-                .with(\.trailingTrivia, .newlines(2))
+                for accessor in stringsTable.ungroupedAccessors {
+                    MemberBlockItemListSyntax {
+                        if accessor.hasArguments {
+                            StringStringsTableResourceFunctionSnippet(accessor: accessor)
+                        } else {
+                            StringStringsTableResourceVariableSnippet(accessor: accessor)
+                        }
+                    }
+                    .with(\.trailingTrivia, .newlines(2))
+                }
+            } else {
+                for accessor in stringsTable.accessors {
+                    MemberBlockItemListSyntax {
+                        if accessor.hasArguments {
+                            StringStringsTableResourceFunctionSnippet(accessor: accessor)
+                        } else {
+                            StringStringsTableResourceVariableSnippet(accessor: accessor)
+                        }
+                    }
+                    .with(\.trailingTrivia, .newlines(2))
+                }
             }
 
             // var bundle: Bundle { ... }

--- a/Sources/StringGenerator/StringGenerator.swift
+++ b/Sources/StringGenerator/StringGenerator.swift
@@ -12,7 +12,8 @@ public struct StringGenerator {
         tableName: String,
         accessLevel: AccessLevel,
         convertFromSnakeCase: Bool,
-        importsUseExplicitAccessLevel: Bool
+        importsUseExplicitAccessLevel: Bool,
+        namespaceGrouping: Bool = false
     ) -> String {
         generateSource(
             for: SourceFile(
@@ -20,6 +21,7 @@ public struct StringGenerator {
                 accessLevel: accessLevel,
                 convertFromSnakeCase: convertFromSnakeCase,
                 importsUseExplicitAccessLevel: importsUseExplicitAccessLevel,
+                namespaceGrouping: namespaceGrouping,
                 resources: resources
             )
         )

--- a/Sources/xcstrings-tool/Generate.swift
+++ b/Sources/xcstrings-tool/Generate.swift
@@ -61,6 +61,9 @@ struct Generate: ParsableCommand {
     @Flag(name: .long)
     var importsUseExplicitAccessLevel: Bool = false
 
+    @Flag(name: .long, help: "Group string accessors into nested enums by the first dot-component of each key")
+    var namespaceGrouping: Bool = false
+
     @Option(
         name: .shortAndLong,
         help: "The development language (defaultLocalization in Package.swift) used when filtering legacy .strings and .stringsdict files from the input paths"
@@ -171,7 +174,8 @@ struct Generate: ParsableCommand {
                 tableName: input.tableName,
                 accessLevel: configuration.accessLevel,
                 convertFromSnakeCase: configuration.convertFromSnakeCase,
-                importsUseExplicitAccessLevel: configuration.importsUseExplicitAccessLevel
+                importsUseExplicitAccessLevel: configuration.importsUseExplicitAccessLevel,
+                namespaceGrouping: configuration.namespaceGrouping
             )
         }
 

--- a/Sources/xcstrings-tool/Utilities/AccessLevel+Resolution.swift
+++ b/Sources/xcstrings-tool/Utilities/AccessLevel+Resolution.swift
@@ -31,8 +31,4 @@ extension AccessLevel {
     }
 }
 
-#if compiler(>=6.0)
-extension AccessLevel: @retroactive ArgumentParser.ExpressibleByArgument {}
-#else
 extension AccessLevel: ExpressibleByArgument {}
-#endif

--- a/Sources/xcstrings-tool/Utilities/Configuration.swift
+++ b/Sources/xcstrings-tool/Utilities/Configuration.swift
@@ -9,6 +9,7 @@ struct Configuration {
         var verbose: Bool?
         var convertFromSnakeCase: Bool?
         var importsUseExplicitAccessLevel: Bool?
+        var namespaceGrouping: Bool?
     }
 
     var accessLevel: AccessLevel
@@ -16,6 +17,7 @@ struct Configuration {
     var verbose: Bool
     var convertFromSnakeCase: Bool
     var importsUseExplicitAccessLevel: Bool
+    var namespaceGrouping: Bool
 }
 
 extension Configuration {
@@ -36,13 +38,15 @@ extension Configuration {
         let verbose = file?.verbose ?? command.verbose
         let convertFromSnakeCase = file?.convertFromSnakeCase ?? command.convertFromSnakeCase
         let importsUseExplicitAccessLevel = file?.importsUseExplicitAccessLevel ?? command.importsUseExplicitAccessLevel
+        let namespaceGrouping = file?.namespaceGrouping ?? command.namespaceGrouping
 
         self.init(
             accessLevel: accessLevel,
             developmentLanguage: developmentLanguage,
             verbose: verbose,
             convertFromSnakeCase: convertFromSnakeCase,
-            importsUseExplicitAccessLevel: importsUseExplicitAccessLevel
+            importsUseExplicitAccessLevel: importsUseExplicitAccessLevel,
+            namespaceGrouping: namespaceGrouping
         )
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `--namespace-grouping` flag (and `namespaceGrouping` config key) that groups string accessors into nested enums by the first dot-component of each key
- Keys like `"bloom.begin.button"` are emitted as `Bloom.beginButton` instead of a flat `bloomBeginButton`, matching the ergonomics of SwiftGen's structured template while keeping native `.xcstrings` support
- Keys without a dot fall through as flat accessors alongside the enums — no breaking change to existing output when the flag is off

## Generated output example

Given keys `bloom.begin.button`, `bloom.commit.button`, `app.tab.today`:

```swift
public enum App {
    public static var tabToday: Localizable { ... }
}

public enum Bloom {
    public static var beginButton: Localizable { ... }
    public static var commitButton: Localizable { ... }
}
```

## Config file usage

```yaml
namespaceGrouping: true
```

## Also fixes

Removes incorrect `@retroactive` on a same-package `ArgumentParser.ExpressibleByArgument` conformance that caused a build error on current Swift toolchains.

## Test plan

- [ ] Existing snapshot tests pass without `--namespace-grouping` (no output change)
- [ ] New snapshot test with `--namespace-grouping` verifies nested enum structure
- [ ] Build passes on Swift 5.9+ and Swift 6